### PR TITLE
Correct minor typo in release strategy

### DIFF
--- a/policies/releasestrat.html
+++ b/policies/releasestrat.html
@@ -28,7 +28,7 @@
 	  contain new features, but in a way that does not break binary
 	  compatibility. This means that an application compiled and
 	  dynamically linked with 1.1.0 does not need to be recompiled
-	  when the shared library is updated to 1.1.0. It should be
+	  when the shared library is updated to 1.1.1. It should be
 	  noted that some features are transparent to the application
 	  such as the maximum negotiated TLS version and cipher suites,
 	  performance improvements and so on. There is no need to


### PR DESCRIPTION
This looks like it should always have gone 1.1.0 -> 1.1.1, but was just missed. I thought about adding a "for example" to that sentence but decided against it: let me know if you want it.