### PR TITLE
code-health: Remove FAQ about compilation on Alpha Tru64

### DIFF
--- a/docs/faq-4-build.txt
+++ b/docs/faq-4-build.txt
@@ -30,45 +30,6 @@ option "no-asm", as described in INSTALL:
 If none of these helps, you may want to try using the current snapshot.
 If the problem persists, please submit a bug report.
 
-* Why does the OpenSSL compilation fail on Alpha Tru64 Unix?
-
-On some Alpha installations running Tru64 Unix and Compaq C, the compilation
-of crypto/sha/sha_dgst.c fails with the message 'Fatal:  Insufficient virtual
-memory to continue compilation.'  As far as the tests have shown, this may be
-a compiler bug.  What happens is that it eats up a lot of resident memory
-to build something, probably a table.  The problem is clearly in the
-optimization code, because if one eliminates optimization completely (-O0),
-the compilation goes through (and the compiler consumes about 2MB of resident
-memory instead of 240MB or whatever one's limit is currently).
-
-There are three options to solve this problem:
-
-1. set your current data segment size soft limit higher.  Experience shows
-that about 241000 kbytes seems to be enough on an AlphaServer DS10.  You do
-this with the command 'ulimit -Sd nnnnnn', where 'nnnnnn' is the number of
-kbytes to set the limit to.
-
-2. If you have a hard limit that is lower than what you need and you can't
-get it changed, you can compile all of OpenSSL with -O0 as optimization
-level.  This is however not a very nice thing to do for those who expect to
-get the best result from OpenSSL.  A bit more complicated solution is the
-following:
-
-<PRE>
-    make DIRS=crypto SDIRS=sha "`grep '^CFLAG=' Makefile.ssl | \
-        sed -e 's/ -O[0-9] / -O0 /'`"
-    rm `ls crypto/*.o crypto/sha/*.o | grep -v 'sha_dgst\.o'`
-    make
-</PRE>
-
-This will only compile sha_dgst.c with -O0, the rest with the optimization
-level chosen by the configuration process.  When the above is done, do the
-test and installation and you're set.
-
-3. Reconfigure the toolkit with no-sha0 option to leave out SHA0. It
-should not be used and is not used in SSL/TLS nor any other recognized
-protocol in either case.
-
 * Why does the OpenSSL compilation fail with "ar: command not found"?
 
 Getting this message is quite usual on Solaris 2, because Sun has hidden


### PR DESCRIPTION
This FAQ entry is about a compiler bug work around. It was last updated
17 years ago and is highly unlikely to be relevant today.