### PR TITLE
fix subhead overflow

### DIFF
--- a/inc/screen.css
+++ b/inc/screen.css
@@ -141,7 +141,6 @@ body > header h2 {
   color: black;
   position: relative;
   top: -0.8em;
-  left: 5em;
 }
 
 #header-open-text {
@@ -655,13 +654,12 @@ body > header h1 a, body > header h1 a:visited, body > header h1 a:hover {
   text-decoration: none;
 }
 body > header h2 {
-  margin: .2em 0 0;
+  margin: .2em 0 0 5em;
   font-weight: 300;
   font-size: 0.8em;
   color: black;
   position: relative;
   top: -0.8em;
-  left: 5em;
 }
 
 body > nav {


### PR DESCRIPTION
When user swipes the website to the right, there's an extra black block. It seems to be the problem of subhead overflow. I fix it now and the test also seems to be ok.  Feel free to correct me.


<img width="1033" alt="screen shot 2560-08-23 at 14 40 56" src="https://user-images.githubusercontent.com/22177001/29603303-3dc67ec8-8816-11e7-86e9-10628b39ae0e.png">
<img width="1280" alt="screen shot 2560-08-23 at 14 39 57" src="https://user-images.githubusercontent.com/22177001/29603304-3dc84168-8816-11e7-80cd-c4c3ef73c941.png">
