### PR TITLE
Document no-space-after-cast

### DIFF
--- a/policies/codingstyle.txt
+++ b/policies/codingstyle.txt
@@ -193,6 +193,9 @@ Do not put a space around the '.' and "->" structure member operators:
     foo.bar
     foo->bar
 
+Do not put a space between a cast and the operand of the cast:
+    (void *)d.names
+
 Do not leave trailing whitespace at the ends of lines. Some editors with
 "smart" indentation will insert whitespace at the beginning of new lines
 as appropriate, so you can start typing the next line of code right away.


### PR DESCRIPTION
Andy recently asserted this as our style, and I've frequently had to check before requesting changes on pull requests (only to not find it written anywhere).