### PR TITLE
Update release strategy for 1.1.1

### DIFF
--- a/policies/releasestrat.html
+++ b/policies/releasestrat.html
@@ -13,7 +13,7 @@
 	  <h2>Release Strategy</h2>
 	  <h5>
 	    First issued 23rd December 2014<br/>
-	    Last modified 6th September 2016
+	    Last modified 1st February 2018
 	  </h5>
 	</header>
 
@@ -52,7 +52,7 @@
 	  project has adopted the following policy:</p>
 
 	  <ul>
-	    <li>Version 1.1.0 will be supported until 2018-08-31.</li>
+	    <li>Version 1.1.0 will be supported until one year after the release of 1.1.1</li>
 	    <li>Version 1.0.2 will be supported until 2019-12-31 (LTS).</li>
             <li>Version 1.0.1 is no longer supported.</li>
 	    <li>Version 1.0.0 is no longer supported.</li>
@@ -69,6 +69,63 @@
 	  fixes. Before that, bug and security fixes will be applied
 	  as appropriate.</p>
 
+	  <p>The next version of OpenSSL will be 1.1.1. This is currently in
+	  development and has a primary focus of implementing TLSv1.3. The
+	  RFC for TLSv1.3 has not yet been published by the IETF. OpenSSL 1.1.1
+	  will not have its final release until that has happened.</p>
+
+	  <p>The draft release timetable for 1.1.1 is as follows. This may be
+          amended at any time as the need arises.</p>
+
+	  <ul>
+	    <li>13th February 2018, alpha release 1 (pre1)</li>
+	    <li>27th February 2018, alpha release 2 (pre2)</li>
+	    <li>13th March 2018, beta release 1 (pre3)
+              <ul>
+	        <li>OpenSSL_1_1_1-stable created (feature freeze)</li>
+	        <li>master becomes basis for 1.1.2 or 1.2.0 (TBD)</li>
+	      </ul>
+	    <li>27th March 2018, beta release 2 (pre4)</li>
+	    <li>10th April 2018, beta release 3 (pre5)</li>
+	    <li>24th April 2018, beta release 4 (pre6)</li>
+	    <li>1st May 2018, release readiness check (new release cycles added if
+	        required, first possible final release date: 8th May 2018)</li>
+	  </ul>
+
+	  <p>An alpha release means:</p>
+	  <ul>
+	    <li>Not (necessarily) feature complete</li>
+	    <li>Not necessarily all new APIs in place yet</li>
+	  </ul>
+
+	  <p>A beta release means:</p>
+	  <ul>
+	    <li>Feature complete/Feature freeze (but may include a non-final implementation of the TLSv1.3 specification)</li>
+	    <li>Bug fixes only</li>
+	  </ul>
+
+	  <p>We have defined the following release criteria for 1.1.1:</p>
+	  <ul>
+	    <li>All open github issues/PRs older than 2 weeks at the time of release
+	    to be assessed for relevance to 1.1.1. Any flagged with the 1.1.1
+	    milestone to be closed (see below)</li>
+	    <li>Clean builds in Travis and Appveyor for two days</li>
+	    <li>run-checker.sh to be showing as clean 2 days before release</li>
+	    <li>No open Coverity issues (not flagged as "False Positive" or "Ignore")</li>
+	    <li>TLSv1.3 RFC published</li>
+	  </ul>
+
+	  <p>Valid reasons for closing an issue/PR with a 1.1.1 milestone might be:</p>
+	  <ul>
+	    <li>We have just now or sometime in the past fixed the issue</li>
+	    <li>Unable to reproduce (following discussion with original reporter if
+	    possible)</li>
+	    <li>Working as intended</li>
+	    <li>Deliberate decision not to fix until a later release (this wouldn't
+	    actually close the issue/PR but change the milestone instead)</li>
+	    <li>Not enough information and unable to contact reporter</li>
+	    <li>etc</li>
+	  </ul>
 	</div>
 	<footer>
 	  You are here: <a href="/">Home</a>


### PR DESCRIPTION
This is the proposed release timetable and release criteria for 1.1.1. It is based on the discussions in this thread:

https://mta.openssl.org/pipermail/openssl-project/2018-January/000184.html

I am inviting reviews and/or approvals now, but I won't push this until the OMC passes a vote on it.