### PR TITLE
inc/screen.css: no pre-wrap

### DIFF
--- a/inc/screen.css
+++ b/inc/screen.css
@@ -362,10 +362,7 @@ article blockquote cite:before {
 
 /* @extend this to force long lines of continuous text to wrap */
 .force-wrap, article a, aside.sidebar a {
-  white-space: -moz-pre-wrap;
-  white-space: -pre-wrap;
-  white-space: -o-pre-wrap;
-  white-space: pre-wrap;
+  white-space: normal;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
There's no reason why the contents of <a> element should be wrapped on
line breaks.  Set white-space to 'normal' instead.

This property is useful in case we happen to inherit some other
setting of that property and want to get back to a normal setting.