### PR TITLE
Add a openssl.com specific .htaccess

### DIFF
--- a/.htaccess.openssl.com
+++ b/.htaccess.openssl.com
@@ -1,0 +1,4 @@
+# -*- Apache -*-
+Redirect permanent / https://www.openssl.org/community/contacts.html
+Redirect permanent /verifycd.html https://www.openssl.org/docs/fips/verifycd.html
+RedirectMatch permanent "^(.*)$" "https://www.openssl.org$1"


### PR DESCRIPTION
This allows us to redirect whatever openssl.com URLs we want freely.
The setup in the openssl.com site configuration will include this line:

    AccessFileName .htaccess.openssl.com .htaccess