### PR TITLE
Fix openssl.com htaccess

### DIFF
--- a/.htaccess.openssl.com
+++ b/.htaccess.openssl.com
@@ -1,4 +1,5 @@
 # -*- Apache -*-
-Redirect permanent / https://www.openssl.org/community/contacts.html
 Redirect permanent /verifycd.html https://www.openssl.org/docs/fips/verifycd.html
+
+RedirectMatch permanent "^/$" https://www.openssl.org/community/contacts.html
 RedirectMatch permanent "^(.*)$" "https://www.openssl.org$1"


### PR DESCRIPTION
Redirect works with prefixes.  If only / should be redirected and not
any sub-path, use RedirectMatch