### PR TITLE
Remove pre-release from 1.1.1

### DIFF
--- a/docs/manpages.html
+++ b/docs/manpages.html
@@ -14,7 +14,7 @@
 	    </p>
             <ul>
               <li><a href="manmaster">master</a></li>
-              <li><a href="man1.1.1">1.1.1 (pre-release)</a></li>
+              <li><a href="man1.1.1">1.1.1</a></li>
               <li><a href="man1.1.0">1.1.0</a></li>
               <li><a href="man1.0.2">1.0.2</a></li>
             </ul>


### PR DESCRIPTION
Reported by Dennis Clarke on [openssl-users](https://mta.openssl.org/pipermail/openssl-users/2018-September/008841.html).