### PR TITLE
Missing the 1.1.1 vulns page which will be needed when any issues get fixed

### DIFF
--- a/bin/mk-cvepage
+++ b/bin/mk-cvepage
@@ -147,7 +147,7 @@ preface += "</p>"
 if allissues != "":
     preface += allissues + "</dl>"
 else:
-    preface += "No vulnerabilities"
+    preface += "No vulnerabilities fixed"
 
 sys.stdout.write(preface.encode('utf-8'))
 

--- a/news/vulnerabilities-1.1.1.html
+++ b/news/vulnerabilities-1.1.1.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--#include virtual="/inc/head.shtml" -->
+
+<body>
+<!--#include virtual="/inc/banner.shtml" -->
+
+  <div id="main">
+    <div id="content">
+      <div class="blog-index">
+	<article>
+	  <header><h2>Vulnerabilities<h2></header>
+	  <div class="entry-content">
+	    <p>
+              If you think you have found a security bug in OpenSSL,
+              please <a href="/community/#securityreports">report it to us</a>.
+	    </p>
+            <!--#include virtual="vulnerabilities-1.1.1.inc" -->
+	    </p>
+	  </div>
+	  <footer>
+	    You are here: <a href="/">Home</a>
+	    : <a href=".">News</a>
+            : <a href="">Vulnerabilities</a>
+	    <br/><a href="/sitemap.txt">Sitemap</a>
+	  </footer>
+	</article>
+      </div>
+      <!--#include virtual="sidebar.shtml" -->
+    </div>
+  </div>
+
+<!--#include virtual="/inc/footer.shtml" -->
+</body>
+
+</html>
+


### PR DESCRIPTION
The page will get automatically referenced by breadcrumbs the first time a fix for a 1.1.1 issue is pushed into the xml, so let's get it ready (the include is already being generated).  Let's also make sure we don't imply there are no vulns at all, just no vulns fixed.