### PR TITLE
inc/screen.css: style <b> and <i> like <strong> and <em>

### DIFF
--- a/inc/screen.css
+++ b/inc/screen.css
@@ -239,11 +239,11 @@ ul ul, ul ol, ol ul, ol ol {
   margin-bottom: 0em;
 }
 
-strong {
+strong, b {
   font-weight: bold;
 }
 
-em {
+em, i {
   font-style: italic;
 }
 


### PR DESCRIPTION
`pod2html` emits the deprecated visual tags instead of the semantic ones,
so we have to style the visual tags as well.

Fixes #74