### PR TITLE
Link to KeyPair arrangement for FIPS CD provision

### DIFF
--- a/docs/fips/verifycd.html
+++ b/docs/fips/verifycd.html
@@ -40,20 +40,20 @@
     The requirement for this verification with an independently acquired
     FIPS 140-2 validated cryptographic module does not apply when the
     distribution file is distributed using a "secure" means. Distribution
-    on physical media is considered secure in this context, so as a
-    convenience a copy of the distribution files can be obtained from
-    <a href="/community/contacts.html">OSS</a> as a CD-ROM disks via postal mail.</p>
+    on physical media is considered secure in this context so you can
+    verify by obtaining a copy of the distribution files on CD-ROM disks via
+    postal mail.</p>
 
-    <p>The fee for this is $100 in US Dollars. At this time we are only able
-      to accept US wire transfers.
-    Email us at <a href="mailto:osf-contact@openssl.org">osf-contact@openssl.org</a>
-    and we will send you our ABA and account information.
-    <b>We cannot do credit cards, purchase orders, or anything other
-      than a US-based bank transfer at this time.</b>
-    We can mail internationally (the CD contains only open source code
-    and so may be exported under the TSU exception of EAR ECCN 5D002).
-    It will take a week or two to process your order.</p>
-
+    <p>OpenSSL are not providing disks directly at this time.  However we have
+    an arrangement with KeyPair Consulting who will
+    <a href="https://keypair.us/2018/05/cd/">send a disk to you at no
+      charge</a>.</p>
+    
+    <blockquote>Important Disclaimer: The listing of these third party products does not
+      imply any endorsement by the OpenSSL project, and these organizations are not
+      affiliated in any way with OpenSSL other than by the reference to their
+      independent web sites here.</blockquote>
+    
     <p>Note that the files you will receive on these CDs will be
     <em>identical</em> in every respect (except for formal FIPS 140-2
     compliance) with the files you can download from <a


### PR DESCRIPTION
Link to a third party who will provide the FIPS CD without direct involvement of OpenSSL