### PR TITLE
Markdown to OpenSSL HTML5 pages

### DIFF
--- a/bin/md-to-html5
+++ b/bin/md-to-html5
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+template="$0.tmpl.html5"
+
+for f in "$@"; do
+    b=`basename "$f" .md`
+    if [ "$f" != "$b" ]; then
+	bns=`echo "$b" | sed -e 's|  *||g'`
+	t=`dirname "$b"`.tmpl.html5
+	if [ ! -f "$t" ]; then
+	    t="$template"
+	fi
+	pandoc -t html5 --template="$t" "$f" > "$bns.html"
+    fi
+done

--- a/bin/md-to-html5.tmpl.html5
+++ b/bin/md-to-html5.tmpl.html5
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--#include virtual="/inc/head.shtml" -->
+
+<body>
+<!--#include virtual="/inc/banner.shtml" -->
+
+  <div id="main">
+    <div id="content">
+      <div class="blog-index">
+        <article>
+$if(title)$
+<header>
+<h1 class="title">$title$</h1>
+$if(subtitle)$
+<p class="subtitle">$subtitle$</p>
+$endif$
+$for(author)$
+<p class="author">$author$</p>
+$endfor$
+$if(date)$
+<p class="date">$date$</p>
+$endif$
+</header>
+$endif$
+$body$
+        </article>
+      </div>
+      <!--#include virtual="sidebar.shtml" -->
+    </div>
+  </div>
+
+<!--#include virtual="/inc/footer.shtml" -->
+</body>


### PR DESCRIPTION
Markdown is a popular format for text files, and some documents are
easier to read in this form than in HTML.  For future purposes, this
is the scripts we need to process markdown files into HTML5.

This script is based on pandoc, which is a pretty good translator
between a range of different document formats.