### PR TITLE
Fix CSS props for code color

### DIFF
--- a/inc/screen.css
+++ b/inc/screen.css
@@ -1084,27 +1084,27 @@ h3.filename + pre {
   border-top-right-radius: 0px;
 }
 
-p code, li code {
-  display: inline-block;
-  white-space: no-wrap;
-  background: #fff;
-  font-size: .8em;
-  line-height: 1.5em;
-  color: #555;
-  border: 1px solid #ddd;
-  -webkit-border-radius: 0.4em;
-  -moz-border-radius: 0.4em;
-  -ms-border-radius: 0.4em;
-  -o-border-radius: 0.4em;
-  border-radius: 0.4em;
-  padding: 0 .3em;
-  margin: -1px 0;
-}
-p pre code, li pre code {
-  font-size: 1em !important;
-  background: none;
-  border: none;
-}
+//p code, li code {
+//  display: inline-block;
+//  white-space: no-wrap;
+//  background: #fff;
+//  font-size: .8em;
+//  line-height: 1.5em;
+//  color: #555;
+//  border: 1px solid #ddd;
+//  -webkit-border-radius: 0.4em;
+//  -moz-border-radius: 0.4em;
+//  -ms-border-radius: 0.4em;
+//  -o-border-radius: 0.4em;
+//  border-radius: 0.4em;
+//  padding: 0 .3em;
+//  margin: -1px 0;
+//}
+//p pre code, li pre code {
+//  font-size: 1em !important;
+//  background: none;
+//  border: none;
+//}
 
 .pre-code, html .highlight pre, .highlight code {
   font-family: Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace !important;


### PR DESCRIPTION
The 'pre' CSS is enough, we have no need for variants for 'p code',
'li code', 'p pre code' and 'li pre code'...
