### PR TITLE
Remove rel=canonical from head.shtml

### DIFF
--- a/inc/head.shtml
+++ b/inc/head.shtml
@@ -9,7 +9,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <link rel="canonical" href="https://www.openssl.org/">
   <link href="/favicon.ico" rel="icon">
   <link href="/inc/screen.css" media="screen, projection" rel="stylesheet" type="text/css">
 


### PR DESCRIPTION
With that line we are claiming that all our web pages are synonyms of the home page.

Fixes #117