### PR TITLE
bin/mk-manpages: allow slashes in names

### DIFF
--- a/bin/mk-manpages
+++ b/bin/mk-manpages
@@ -65,7 +65,9 @@ sub main {
                 print $fh $out or $class->die("Can't print $outinc: $!");
                 close($fh) or $class->die("Can't close $outinc: $!");
 
-                foreach my $htmlname (@{$data{names}}) {
+                foreach my $htmlname (
+                    map { (my $x = $_) =~ s|/|-|g; $x }
+                        @{$data{names}}) {
                     my $htmlfile = File::Spec->catdir( $data{sect},
                                                        "$htmlname.html" );
                     my $outhtml = File::Spec->catfile( $wwwdir, $htmlfile );


### PR DESCRIPTION
The names in the NAME section may describe headers, which contain a slash
for OpenSSL headers.  We deal with that by converting slashes to dashes
for the file names.