### PR TITLE
OpenSSL300Design: lighten watermark

### DIFF
--- a/bin/md-to-html5.tmpl.html5
+++ b/bin/md-to-html5.tmpl.html5
@@ -8,7 +8,7 @@ $endfor$
 <style type="text/css">
   .state {
       position: fixed;
-      color: rgba(0,0,0,0.1);
+      color: rgba(0,0,0,0.025);
       font-family: sans-serif;
       font-size: 25vh;
       transform-origin: right top;


### PR DESCRIPTION
The strong DRAFT watermark is very distracting while reading and makes
the eyes loose the current reading position while scrolling.

Noticed while reading https://www.openssl.org/docs/OpenSSL300Design.html
