### PR TITLE
When producing HTML man-pages, include the original base name

### DIFF
--- a/bin/mk-manpages
+++ b/bin/mk-manpages
@@ -64,9 +64,17 @@ sub main {
                 print $fh $out or $class->die("Can't print $outinc: $!");
                 close($fh) or $class->die("Can't close $outinc: $!");
 
-                foreach my $htmlname (
-                    map { (my $x = $_) =~ s|/|-|g; $x }
-                        @{$data{names}}) {
+                my @htmlnames =
+                    map { (my $x = $_) =~ s|/|-|g; $x } @{$data{names}};
+                # Older OpenSSL pods have file names that do not correspond
+                # to any of the names in the NAME section.
+                # Strictly speaking, we shouldn't use that name, but HTML
+                # pages with that name have been produced in the past, so
+                # we keep doing so as long as it's relevant.
+                if (! grep { $_ eq $origbase } @htmlnames) {
+                    push @htmlnames, $origbase;
+                }
+                foreach my $htmlname (@htmlnames) {
                     my $htmlfile = File::Spec->catdir( "man$data{sectnum}",
                                                        "$htmlname.html" );
                     my $outhtml = File::Spec->catfile( $wwwdir, $htmlfile );


### PR DESCRIPTION
For OpenSSL 1.1.0 and on, this isn't relevant any more, since all pod
names should be one of the names in the NAME section.  However, 1.0.2
pages were written differently, and people still refer to the original
base name to look up documentation.

Fixes openssl/openssl#9189