### PR TITLE
Include description of a trivial commit.

### DIFF
--- a/policies/cla.html
+++ b/policies/cla.html
@@ -12,7 +12,7 @@
 	  <header><h2>Contributor Agreements</h2></header>
 	  <div class="entry-content">
             <p>
-            Every non-trival contribution to be
+            Every non-trivial contribution to be
             covered by a signed
 	    Contributor License Agreement (CLA).
 	    We have modelled our policy based on the practice of
@@ -31,10 +31,27 @@
 	  the terms under which intellectual property has been contributed
 	  to OpenSSL and thereby allow us to defend the project should
 	  there be a legal dispute regarding the software at some future
-	  time.</p>
+	  time.
+	  </p>
 
 	  <p>
-	  <em>Please make sure that the email
+	  A submission is trivial if it is considered trivial under copyright
+	  law. Since we are not lawyers, we place the bar for trivial
+	  contributions very high. For example: corrections of grammatical or
+	  typographical errors (including misspelled function names in manual
+	  pages), simple whitespace changes and in some cases one-line
+	  bugfixes might be accepted as trivial without requiring a CLA.
+	  </p>
+
+	  <p>
+	  In practice, it is required that the author (in the git commit
+	  message) and all approving team members (in the pull request thread)
+	  agree that a change is trivial. The reviewers will normally post
+	  a statement to the effect of "I agree that it is a trivial change."
+	  </p>
+
+	  <p>
+	  <em>When filling in the CLA, please make sure that the email
 	  address matches the one that you use for the "Author" in your
 	  git commits.	List multiple email addresses if necessary.</em>
 	  </p>

--- a/policies/committers.html
+++ b/policies/committers.html
@@ -123,9 +123,9 @@
               <h2>A note on CLAs</h2>
               <p>All authors, including committers, must have current <a href="/policies/cla.html">CLAs</a> on
               file. A CLA is not required for trivial contributions (e.g. the
-              fix of a spelling mistake). If all reviewers as well as the
-              original author agree that the submission is trivial, the commit
-              text should include "CLA: trivial."</p>
+              fix of a spelling mistake). Refer to the
+              <a href="cla.html">CLA</a> page for further details.
+              </p>
 
 	    </div>
 


### PR DESCRIPTION
Trivial submissions are mentioned but not defined even though this is the page referenced when a submission is made without a CLA.

If this is a policy change, an OMC vote will be required.
