### PR TITLE
Sync the OSF sponsorship page with the current sponsors

### DIFF
--- a/support/acks.html
+++ b/support/acks.html
@@ -17,7 +17,7 @@
 
 
 	  <p>We would like to identify and thank the following sponsors
-	  for their donations which give significant support of the OpenSSL project.
+	  for their donations which give significant support to the OpenSSL project.
 	  Please note some sponsors remain anonymous.</p>
           <hr noshade size=1>
 

--- a/support/acks.html
+++ b/support/acks.html
@@ -7,19 +7,19 @@
   <div id="content">
     <div class="blog-index">
       <article>
-	<header><h2>Sponsor Acknowledgements</h2></header>
+	<header><h2>Acknowledgements</h2></header>
 	<div class="entry-content">
 	  <p>The OpenSSL project depends on volunteer efforts and financial
 	  support from the end user community.  That support comes
           in <a href="donations.html">many forms.</a>
 
-	  <p>We would like to identify and thank the following such sponsors
-	  for their significant support of the OpenSSL project. Sponsors are
-	  listed alphabetically within categories.  Please note that we ask
-	  permission to identify sponsors and that some sponsors we consider
-	  eligible for inclusion here have requested to remain anonymous.</p>
+          <h3 id="current">Sponsorship Donations</h3>
 
-          <h3 id="current">Current Sponsors:</h3>
+
+	  <p>We would like to identify and thank the following sponsors
+	  for their donations which give significant support of the OpenSSL project.
+	  Please note some sponsors remain anonymous.</p>
+          <hr noshade size=1>
 
           <style type="text/css">
             .sponsorlogo {
@@ -37,44 +37,60 @@
             text-align: center !important;
             }
           </style>
-          
-	  <hr noshade size=1>
-	  <p>Exceptional support:</p>
+
+          <h4>Exceptional:</h4>
 
           <div class="sponsorsection">
-	  <a href="https://www.akamai.com/"><img src="/img/akamai-logo-med.png"
-	  alt="" class="sponsorlogo"></a>
 	  <a href="https://www.smartisan.com/"><img src="/img/smartisan-logo-med.png"
 	  alt="" class="sponsorlogo"></a>
           </div>
 
-          <p></p>          
-	  <hr noshade size=1>
-	  <p>Platinum support:</p>
+          <h4>Platinum:</h4>
 
           <div class="sponsorsection">
-	  <a href="https://www.bluecedar.com/"><img src="/img/bluecedar-logo-med.png"
-	  alt="" class="sponsorlogo"></a>          
 	  <a href="https://www.huawei.com/"><img src="/img/huawei-logo-med.jpg"
-	  alt="" class="sponsorlogo"></a>
-	  <a href="https://www.netapp.com/"><img src="/img/netapp-logo-med.jpg"
-	  alt="" class="sponsorlogo"></a>          
-	  <a href="https://www.oracle.com/"><img src="/img/oracle-logo-med.jpg"
-	  alt="" class="sponsorlogo"></a>
-	  <a href="https://www.vmware.com/"><img src="/img/vmware-logo-med.jpg"
 	  alt="" class="sponsorlogo"></a>
           </div>
 
-<!--	  <hr noshade size=1>
-	  <p>Gold support:</p>
+          <h4>Bronze:</h4>
+          <div class="sponsorsection">
+          <p><a href="https://cargurus.com/">CarGurus</a></p>
+          </div>
 
-	  <hr noshade size=1>
-	  <p>Silver support:</p>
-          -->
-
+	  <h4>Past sponsors include:</h4> 
+          <dl>
+            <dd>2018: <a href="https://www.akamai.com/">Akamai</a>,
+              <a href="https://www.bluecedar.com/">Blue Cedar</a>,
+              <a href="https://www.handshake.org/">Handshake</a>,
+              <a href="https://www.huawei.com/">Huawei</a>,
+              <a href="https://levchinprize.com/">Levchin Prize</a>,
+              <a href="https://www.netapp.com/">NetApp</a>,
+              <a href="https://www.smartisan.com/">Smartisan</a>,
+              and
+              <a href="https://vmware.com/">VMWare</a>.
+            </dd>
+            <dd>2017: <a href="https://www.akamai.com/">Akamai</a>,
+              <a href="https://www.huawei.com/">Huawei</a>,
+              <a href="https://www.oracle.com/">Oracle</a>,
+              and
+              <a href="https://www.smartisan.com/">Smartisan</a>.
+            </dd>
+            <dd>2016: <a href="https://www.huawei.com/">Huawei</a>,
+              <a href="https://www.coreinfrastructure.org/">Linux Foundation
+                Core Infrastructure Initiative</a>,
+              and
+              <a href="https://www.smartisan.com/">Smartisan</a>.
+            </dd>            
+          </dl>
           <p></p>
           <hr noshade size=1>
-
+          <h3>Other Donations</h3>
+	  <div class="entry-content">
+	    <p>
+	      We also identify and thank organizations who contribute
+              <a href="/community/thanks.html"> in-kind donations to the project</a>.
+	    </p>
+	  </div>
 
 	  </div>
 	  <footer>

--- a/support/donations.html
+++ b/support/donations.html
@@ -48,6 +48,9 @@
 	      <tr><td>Silver<br>$10,000/yr</td>
                 <td>Acknowledgement on openssl.org</td></tr>
 
+	      <tr><td>Bronze<br>$5,000/yr</td>
+                <td>Acknowledgement on openssl.org</td></tr>
+
 	    </table>
 	    <p>&nbsp;</p>
 


### PR DESCRIPTION
Sync to the current list of OSF sponsors.  Add a bronze level and the current sponsors at that level.
Add a link to the 'in kind' thanks page. Add a new section to call out our past sponsors.