### PR TITLE
Drop 1.1.0 as a current release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,14 @@ RELEASEDIR = /var/www/openssl/source
 ##
 
 ##  Current series
-SERIES=1.1.1 1.1.0 1.0.2
+SERIES=1.1.1 1.0.2
 ##  Older series.  The second type is for source listings
-OLDSERIES=1.0.1 1.0.0 0.9.8 0.9.7 0.9.6
-OLDSERIES2=1.0.1 1.0.0 0.9.x
+OLDSERIES=1.1.0 1.0.1 1.0.0 0.9.8 0.9.7 0.9.6
+OLDSERIES2=1.1.0 1.0.1 1.0.0 0.9.x
 ##  Current series with newer and older manpage layout
 ##  (when the number of old man layout releases drop to none, this goes away)
 NEWMANSERIES=1.1.1
-OLDMANSERIES=1.1.0 1.0.2
+OLDMANSERIES=1.0.2
 
 # All simple generated files.
 SIMPLE = newsflash.inc sitemap.txt \

--- a/source/index.html
+++ b/source/index.html
@@ -34,11 +34,12 @@
         also our Long Term Support (LTS) version, supported until 11th September
         2023. Our previous LTS version (1.0.2 series) will continue to be
         supported until 31st December 2019 (security fixes only during the last
-        year of support). The 1.1.0 series is currently only receiving security
-        fixes and will go out of support on 11th September 2019. All users of
-        1.0.2 and 1.1.0 are encouraged to upgrade to 1.1.1 as soon as possible.
-        The 0.9.8, 1.0.0 and 1.0.1 versions are now out of support and should
-        not be used.</p>
+        year of support). All users of 1.0.2 are encouraged to upgrade to 1.1.1
+        as soon as possible. Extended support for 1.0.2 to gain access to
+        security fixes beyond 31st December 2019 is
+        <a href="/support/contracts.html">available</a>.
+        The 0.9.8, 1.0.0, 1.0.1 and 1.1.0 versions are now out of support and
+        should not be used.</p>
 
         <p>The OpenSSL FIPS Object Module 2.0 (FOM) is also available for
         download. It is no longer receiving updates. It must be used in


### PR DESCRIPTION
Don't refer to 1.1.0 as a current release since it is no longer supported.