### PR TITLE
Remove an additional 1.1.0 reference

### DIFF
--- a/inc/mansidebar.shtml
+++ b/inc/mansidebar.shtml
@@ -5,7 +5,6 @@
     <ul>
       <li><a href="/docs/manmaster">master</a></li>
       <li><a href="/docs/man1.1.1">1.1.1</a></li>
-      <li><a href="/docs/man1.1.0">1.1.0</a></li>
       <li><a href="/docs/man1.0.2">1.0.2</a></li>
     </ul>
   </section>


### PR DESCRIPTION
We previously removed references to 1.1.0 as a current release. There is
one remaining spot that was missed, so we update that too.