### PR TITLE
Update the vulnerability XML to also include some statements about EOL

### DIFF
--- a/bin/mk-cvepage
+++ b/bin/mk-cvepage
@@ -140,6 +140,9 @@ preface += "<p>Show issues fixed only in OpenSSL " + ", ".join(bases)
 if options.base:
     preface += ", or <a href=\"vulnerabilities.html\">all versions</a>"
     preface += "<h2>Fixed in OpenSSL %s</h2>" %(options.base)
+    for statement in dom.getElementsByTagName('statement'):
+        if (statement.getAttribute("base") in options.base):
+            preface += statement.firstChild.data.strip()
 preface += "</p>"
 if len(allyears)>1: # If only vulns in this year no need for the year table of contents
     preface += "<p><a name=\"toc\">Jump to year: </a>" + ", ".join( "<a href=\"#y%s\">%s</a>" %(year,year) for year in allyears)

--- a/news/vulnerabilities.xml
+++ b/news/vulnerabilities.xml
@@ -7336,6 +7336,14 @@ default and not common.</description>
   <advisory url="/news/secadv/20140605.txt"/>
 </issue>
 
+  <statement base="0.9.6">OpenSSL 0.9.6 is out of support and no longer receiving updates.</statement>
+  <statement base="0.9.7">OpenSSL 0.9.7 is out of support and no longer receiving updates.</statement>
+  <statement base="0.9.8">OpenSSL 0.9.8 is out of support since 1st January 2016 and no longer receiving updates.</statement>
+  <statement base="1.0.0">OpenSSL 1.0.0 is out of support since 1st January 2016 and no longer receiving updates.</statement>
+  <statement base="1.0.1">OpenSSL 1.0.1 is out of support since 1st January 2017 and no longer receiving updates.</statement>
+  <statement base="1.0.2">OpenSSL 1.0.2 is out of support since 1st January 2020 and is no longer receiving updates.  Extended support is available from OpenSSL Software Services for premium support customers</statement>
+  <statement base="1.1.0">OpenSSL 1.1.0 is out of support since 12th September 2019 and no longer receiving updates.</statement>
+
 </security>
 
 


### PR DESCRIPTION
This way we can make it clear on the vulnerability page when things are EOL, for example https://www.openssl.org/news/vulnerabilities-0.9.8.html