### PR TITLE
Allow a default statement if our page is not for a specific base version

### DIFF
--- a/bin/mk-cvepage
+++ b/bin/mk-cvepage
@@ -138,12 +138,13 @@ for base in allyourbase(dom):
         bases.append( "<a href=\"vulnerabilities-%s.html\">%s</a>" %(base,base))
 preface += "<p>Show issues fixed only in OpenSSL " + ", ".join(bases)
 if options.base:
-    preface += ", or <a href=\"vulnerabilities.html\">all versions</a>"
+    preface += ", or <a href=\"vulnerabilities.html\">all versions</a></p>"
     preface += "<h2>Fixed in OpenSSL %s</h2>" %(options.base)
-    for statement in dom.getElementsByTagName('statement'):
-        if (statement.getAttribute("base") in options.base):
-            preface += statement.firstChild.data.strip()
-preface += "</p>"
+else:
+    preface += "</p>"
+for statement in dom.getElementsByTagName('statement'):
+    if (statement.getAttribute("base") in (options.base or "none")):
+        preface += "<p>"+statement.firstChild.data.strip()+"</p>"
 if len(allyears)>1: # If only vulns in this year no need for the year table of contents
     preface += "<p><a name=\"toc\">Jump to year: </a>" + ", ".join( "<a href=\"#y%s\">%s</a>" %(year,year) for year in allyears)
 preface += "</p>"

--- a/news/vulnerabilities.xml
+++ b/news/vulnerabilities.xml
@@ -7336,6 +7336,7 @@ default and not common.</description>
   <advisory url="/news/secadv/20140605.txt"/>
 </issue>
 
+  <statement base="none">Note: All OpenSSL versions before 1.1.1 are out of support and no longer receiving updates.  Extended support is available for 1.0.2 from OpenSSL Software Services for premium support customers.</statement>
   <statement base="0.9.6">OpenSSL 0.9.6 is out of support and no longer receiving updates.</statement>
   <statement base="0.9.7">OpenSSL 0.9.7 is out of support and no longer receiving updates.</statement>
   <statement base="0.9.8">OpenSSL 0.9.8 is out of support since 1st January 2016 and no longer receiving updates.</statement>


### PR DESCRIPTION
also clean up the HTML we closed the p tag in the wrong place.  Add a
statement on all the versions out of support.