### PR TITLE
Create an OTC page on the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ blog
 sitemap.txt
 community/committers.inc
 community/omc-alumni.inc
+community/otc.inc
 community/omc.inc
 docs/OpenSSL300Design.html
 docs/OpenSSLStrategicArchitecture.html

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ OLDMANSERIES=1.0.2
 # All simple generated files.
 SIMPLE = newsflash.inc sitemap.txt \
 	 community/committers.inc \
-	 community/omc.inc community/omc-alumni.inc \
+	 community/otc.inc community/omc.inc community/omc-alumni.inc \
 	 docs/faq.inc docs/fips.inc \
 	 docs/OpenSSLStrategicArchitecture.html \
 	 docs/OpenSSL300Design.html \
@@ -153,7 +153,7 @@ docs/manpages.html: docs/manpages.html.tt
 ##
 ##  $(SIMPLE) -- SIMPLE GENERATED FILES
 ##
-.PHONY: sitemap community/committers.inc community/omc.inc community/omc-alumni.inc
+.PHONY: sitemap community/committers.inc community/otc.inc community/omc.inc community/omc-alumni.inc
 newsflash.inc: news/newsflash.inc
 	@rm -f $@
 	head -7 $? >$@
@@ -167,6 +167,8 @@ community/committers.inc:
 	./bin/mk-committers <Members >$@
 	@rm -f Members
 
+community/otc.inc:
+	./bin/mk-omc -n -t 'OTC Members' otc otc-inactive > $@
 community/omc.inc:
 	./bin/mk-omc -n -e -l -p -t 'OMC Members' omc omc-inactive > $@
 community/omc-alumni.inc:

--- a/community/index.html
+++ b/community/index.html
@@ -16,6 +16,8 @@
             <a href="committers.html">team of committers</a>.
             The overall project is run by the
             <a href="omc.html">OpenSSL Management Committee</a>.
+            Technical decisions are made by the
+            <a href="otc.html">OpenSSL Technical Committee</a>.
             We operate under a set of
             <a href="/policies/omc-bylaws.html">project bylaws</a>
             and ask everyone to follow our

--- a/community/otc.html
+++ b/community/otc.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--#include virtual="/inc/head.shtml" -->
+
+<body>
+<!--#include virtual="/inc/banner.shtml" -->
+
+<div id="main">
+  <div id="content">
+    <div class="blog-index">
+      <article>
+        <header><h2>OpenSSL Technical Committee</h2></header>
+        <div class="entry-content">
+          <p> The
+              <a href="/policies/omc-bylaws.html#OTC">OpenSSL Technical Committee</a>
+              represents the official technical voice of the project. All
+              OTC decisions are taken on the basis of a vote.</p>
+          <p>
+          The current OTC consists of (in alphabetical order):
+          </p>
+
+          <!--#include virtual="otc.inc" -->
+
+          Names with an (I) are currently inactive as defined in our
+          <a href="/policies/omc-bylaws.html">bylaws</a>.
+
+        </div>
+
+        <footer>
+          You are here: <a href="/">Home</a>
+          : <a href=".">Community</a>
+          : <a href="">OTC</a>
+          <br/><a href="/sitemap.txt">Sitemap</a>
+        </footer>
+      </article>
+    </div>
+    <!--#include virtual="sidebar.shtml" -->
+  </div>
+</div>
+<!--#include virtual="/inc/footer.shtml" -->
+</body>
+</html>

--- a/community/sidebar.shtml
+++ b/community/sidebar.shtml
@@ -7,6 +7,9 @@
 	  <a href="committers.html">List of Committers</a>
       </li>
       <li>
+	  <a href="otc.html">OpenSSL Technical Committee</a>
+      </li>
+      <li>
 	  <a href="omc.html">OpenSSL Management Committee</a>
       </li>
       <li>


### PR DESCRIPTION
I *think* I got everything I needed to implement this. I've tested it as far as I am able, but I can't check that it all works together.

This is based on the OMC page with a few edits. Most notably I've restricted the table to only show the names of members and not email address, locales or PGP keys. This is because that information is missing for a number of the members and the scripts were falling over. I'm also not sure if we actually need to show that information. For now I've just made it simple.