### PR TITLE
Strip JSON whitespace after commas

### DIFF
--- a/bin/vulnxml2json.py
+++ b/bin/vulnxml2json.py
@@ -146,7 +146,7 @@ for issue in cvej:
        continue
 
     f = codecs.open(options.outputdir+"/"+fn, 'w', 'utf-8')
-    f.write(json.dumps(issue, sort_keys=True, indent=4))
+    f.write(json.dumps(issue, sort_keys=True, indent=4, separators=(',',': ')))
     print "wrote %s" %(options.outputdir+"/"+fn)
     f.close()
 


### PR DESCRIPTION
Mitre are doing this to our submissions, so let's  do that by default.  But they are keeping the whitespace after :.

fixes #160