### PR TITLE
Simple fix for #159 if we can't open the schema tell the user how to fix it

### DIFF
--- a/bin/vulnxml2json.py
+++ b/bin/vulnxml2json.py
@@ -39,7 +39,11 @@ if not options.input:
    exit();
 
 if options.schema:
-   response = urllib.urlopen(options.schema)
+   try:
+      response = urllib.urlopen(options.schema)
+   except:
+      print "Problem opening schema: try downloading it manually then specify it using --schema option: %s" % options.schema
+      exit()
    schema_doc = json.loads(response.read())
 
 cvej = list()


### PR DESCRIPTION
We actually need to do that because some older? Ubuntu systems were having problems with the
CA cert from github

fixes #159 