### PR TITLE
Don't die if we only have one tarball

### DIFF
--- a/bin/mk-latest
+++ b/bin/mk-latest
@@ -9,7 +9,6 @@ chdir $SRCDIR || die "Can't chdir $SRCDIR, $!";
 my @tarballs =
        sort grep /openssl-\d+\.\d+\.\d+[a-z]*\.tar\.gz$/,
                glob("openssl-*.tar.gz");
-die "No tgz files found in $SRCDIR?\n" if $#tarballs < 1;
 
 my %series = ();
 foreach(@tarballs) {


### PR DESCRIPTION
mk-latest incorrectly dies if there is only one tarball. The value of
$#tarballs is 0 if there is 1 tarball.