### PR TITLE
Update the Release schedule in the release strategy

### DIFF
--- a/policies/releasestrat.html
+++ b/policies/releasestrat.html
@@ -107,20 +107,9 @@
 	    <li>Bug fixes only</li>
 	  </ul>
 
-	  <p>The following alpha and beta releases for OpenSSL 3.0 are currently
-	  scheduled. Note that these dates are subject to change and alpha or beta
-	  releases may be inserted or removed as required:</p>
-	  <ul>
-	    <li>alpha1, 2020-03-31: Basic functionality plus basic FIPS module</li>
-	    <li>alpha2, 2020-04-21: Complete external provider support (serialization,
-	    support for new algs, support for providers which only include
-	    operations in a class)</li>
-	    <li>alpha3, 2020-05-21: Aiming to test the API completeness before beta1
-	    freezes it)</li>
-	    <li>beta1, 2020-06-02: Code complete (API stable, feature freeze)</li>
-	    <li>betaN: Other beta releases TBD</li>
-	    <li>Final: 2020 early Q4</li>
-	  </ul>
+	  <p>The OpenSSL 3.0 release schedule is documented on the
+	  <a href="https://wiki.openssl.org/index.php/OpenSSL_3.0_Release_Schedule">OpenSSL 3.0 Release Schedule</a>
+	  wiki page</p>
       
 	  <p>
 	    For any major or minor release, we have defined the following

--- a/policies/releasestrat.html
+++ b/policies/releasestrat.html
@@ -109,7 +109,7 @@
 
 	  <p>The OpenSSL 3.0 release schedule is documented on the
 	  <a href="https://wiki.openssl.org/index.php/OpenSSL_3.0_Release_Schedule">OpenSSL 3.0 Release Schedule</a>
-	  wiki page</p>
+	  wiki page. We expect the final release to be in early Q4 2020.</p>
       
 	  <p>
 	    For any major or minor release, we have defined the following


### PR DESCRIPTION
Update the release strategy to remove the 3.0 release schedule, and instead point to a Wiki page with that information in. The schedule in the strategy is very out of date and needs to be updated. Rather than updating the strategy every time there is an update it would be better to hold that schedule in a wiki page which can be easily updated.

At the moment the wiki page just holds exactly the same dates.

As this is a policy change it will need an OMC vote.