### PR TITLE
Add beslist.nl to the sponsor list and remove past sponsor section

### DIFF
--- a/support/acks.html
+++ b/support/acks.html
@@ -54,34 +54,10 @@
 
           <h4>Bronze:</h4>
           <div class="sponsorsection">
-          <p><a href="https://cargurus.com/">CarGurus</a></p>
+            <p><a href="https://beslist.nl/">beslist.nl</a></p>
+            <p><a href="https://cargurus.com/">CarGurus</a></p>
           </div>
 
-	  <h4>Past sponsors include:</h4> 
-          <dl>
-            <dd>2018: <a href="https://www.akamai.com/">Akamai</a>,
-              <a href="https://www.bluecedar.com/">Blue Cedar</a>,
-              <a href="https://www.handshake.org/">Handshake</a>,
-              <a href="https://www.huawei.com/">Huawei</a>,
-              <a href="https://levchinprize.com/">Levchin Prize</a>,
-              <a href="https://www.netapp.com/">NetApp</a>,
-              <a href="https://www.smartisan.com/">Smartisan</a>,
-              and
-              <a href="https://vmware.com/">VMWare</a>.
-            </dd>
-            <dd>2017: <a href="https://www.akamai.com/">Akamai</a>,
-              <a href="https://www.huawei.com/">Huawei</a>,
-              <a href="https://www.oracle.com/">Oracle</a>,
-              and
-              <a href="https://www.smartisan.com/">Smartisan</a>.
-            </dd>
-            <dd>2016: <a href="https://www.huawei.com/">Huawei</a>,
-              <a href="https://www.coreinfrastructure.org/">Linux Foundation
-                Core Infrastructure Initiative</a>,
-              and
-              <a href="https://www.smartisan.com/">Smartisan</a>.
-            </dd>            
-          </dl>
           <p></p>
           <hr noshade size=1>
           <h3>Other Donations</h3>


### PR DESCRIPTION
Add beslist.nl to the sponsor list for the bronze equivalent github level.  Remove the list of past sponsors, this would be better served perhaps as a yearly blog post giving details of the health of the project.