### PR TITLE
Add 'OpenSSL Technical Policies' page with a 'Voting Policy' section

### DIFF
--- a/policies/index.html
+++ b/policies/index.html
@@ -61,6 +61,13 @@
             Signing one of our CLA's grants certain rights to OSF.
             </p>
 	    <p>
+	    <p>
+            The technical aspects of the OpenSSL project are managed by the
+            OpenSSL Technical Committee (OTC) which establishes and maintains
+            the <a href="otc-policies.html">technical policies</a> based on the
+            project bylaws and the requirements specified by the OMC.
+            </p>
+	    <p>
 	    We are pleased to mention that
             <a href="https://bestpractices.coreinfrastructure.org/projects/54">we follow</a>
             the

--- a/policies/omc-bylaws.html
+++ b/policies/omc-bylaws.html
@@ -262,7 +262,7 @@
           to vote on and participate in discussions. They retain access to OTC
           internal resources.</p>
 
-          <h4><a name="voting">OTC Voting Procedures</a></h4>
+          <h4><a name="otc-voting">OTC Voting Procedures</a></h4>
 
           <p>A vote will pass if it has had a vote registered from
           a majority of active OTC members and has had more votes registered in

--- a/policies/omc-bylaws.html
+++ b/policies/omc-bylaws.html
@@ -152,7 +152,7 @@
           to vote on and participate in discussions. They retain access to OMC
           internal resources.</p>
 
-          <h4><a name="voting">OMC Voting Procedures</a></h4>
+          <h4><a name="omc-voting">OMC Voting Procedures</a></h4>
 
           <p>A vote to change these bylaws will pass if it obtains an in favour
           vote by more than two thirds of the active OMC members and less than
@@ -294,7 +294,7 @@
           <p>All votes and their outcomes should be recorded and available to
           all OTC and OMC members.</p>
 
-          <h4><a name="transparency">OTC Transparency</a></h4>
+          <h4><a name="otc-transparency">OTC Transparency</a></h4>
           <p>
           The majority of the activity of the OTC will take place in public.
           Non-public discussions or votes shall only occur for issues such as:

--- a/policies/otc-policies.html
+++ b/policies/otc-policies.html
@@ -20,7 +20,7 @@
         <div class="entry-content">
 
           <p>This document lists the technical policies and procedures established
-          by the OTC based on the <a href="omc-bylaws.html">project bylaws</a>
+          by the OTC in accordance with the <a href="omc-bylaws.html">project bylaws</a>
           and the requirements specified by the OMC.</p>
 
           <h3><a name="voting-procedure">Voting Procedure</a></h3>

--- a/policies/otc-policies.html
+++ b/policies/otc-policies.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--#include virtual="/inc/head.shtml" -->
+
+<body>
+<!--#include virtual="/inc/banner.shtml" -->
+
+<div id="main">
+  <div id="content">
+    <div class="blog-index">
+      <article>
+        <header>
+          <h2>OpenSSL Technical Policies</h2>
+          <h5>
+            First issued 30th September 2020<br/>
+            Last modified 30th September 2020
+          </h5>
+        </header>
+
+        <div class="entry-content">
+
+          <p>This document lists the technical policies and procedures established
+          by the OTC based on the <a href="omc-bylaws.html">project bylaws</a>
+          and the requirements specified by the OMC.</p>
+
+
+      <h2><a name="update">Update History</a></h2>
+      <ul>
+        <li>30-September-2020.
+        Initial revision.</li>
+      </ul>
+
+        </div>
+        <footer>
+          You are here: <a href="/">Home</a>
+          : <a href="/policies">Policies</a>
+          : <a href="">Technical Policies</a>
+          <br/><a href="/sitemap.txt">Sitemap</a>
+        </footer>
+      </article>
+    </div>
+    <!--#include virtual="sidebar.shtml" -->
+  </div>
+</div>
+
+<!--#include virtual="/inc/footer.shtml" -->
+</body>
+
+</html>
+

--- a/policies/otc-policies.html
+++ b/policies/otc-policies.html
@@ -25,7 +25,7 @@
 
           <h3><a name="voting-procedure">Voting Procedure</a></h3>
 
-          The following implementary regulations complement the
+          The following regulations complement the
           <a href="omc-bylaws.html#otc-voting">OTC Voting Procedures</a>
           stated in the project bylaws:
 

--- a/policies/otc-policies.html
+++ b/policies/otc-policies.html
@@ -29,10 +29,12 @@
           <a href="omc-bylaws.html#otc-voting">OTC Voting Procedures</a>
           stated in the project bylaws:
 
-          <p>The proposer of a vote is ultimately responsible for updating the votes.txt
-          file in the repository.  Outside of a face to face meeting, voters MUST reply
-          to the vote email indicating their preference and optionally their reasoning.
-          Voters MAY update the votes.txt file in addition.</p>
+          <p>The proposer of a vote is ultimately responsible for updating the
+          <a href="https://git.openssl.org/?p=otc.git;f=votes.txt;hb=HEAD">votes.txt</a>
+          file in the <a href="https://git.openssl.org/?p=otc.git">OTC Git repository</a>.
+          Outside of a face to face meeting, voters MUST reply to the vote email indicating
+          their preference and optionally their reasoning.  Voters MAY update the votes.txt
+          file in addition.</p>
 
           <p>The proposed vote text SHOULD be raised for discussion before calling the vote.</p>
 

--- a/policies/otc-policies.html
+++ b/policies/otc-policies.html
@@ -23,6 +23,22 @@
           by the OTC based on the <a href="omc-bylaws.html">project bylaws</a>
           and the requirements specified by the OMC.</p>
 
+          <h3><a name="voting-procedure">Voting Procedure</a></h3>
+
+          The following implementary regulations complement the
+          <a href="omc-bylaws.html#otc-voting">OTC Voting Procedures</a>
+          stated in the project bylaws:
+
+          <p>The proposer of a vote is ultimately responsible for updating the votes.txt
+          file in the repository.  Outside of a face to face meeting, voters MUST reply
+          to the vote email indicating their preference and optionally their reasoning.
+          Voters MAY update the votes.txt file in addition.</p>
+
+          <p>The proposed vote text SHOULD be raised for discussion before calling the vote.</p>
+
+          <p>Public votes MUST be called on the project list, not the OTC list and the
+          subject MUST begin with “VOTE:”.  Private votes MUST be called on the
+          OTC list with “PRIVATE VOTE:” beginning subject.</p>
 
       <h2><a name="update">Update History</a></h2>
       <ul>


### PR DESCRIPTION
This pull request realizes the first technical policy of the OTC, as decided at the vF2F meeting, see

- [[openssl-project] - VOTE: Accept the OTC voting policy as defined](https://mta.openssl.org/pipermail/openssl-project/2020-September/002250.html)
- [[openssl-project] - Add 'OpenSSL Technical Policies' page to openssl.org?](https://mta.openssl.org/pipermail/openssl-project/2020-September/002255.html)

@openssl/otc I wrapped the formulation of the voting policy into some boilerplate text, trying hard not to add any policy or text which was not written down yet in the bylaws or elsewhere on the project page. Please let me know whether the result is acceptable for you by adding your GitHub approvals here or providing review feedback. 