### PR TITLE
policies/sidebar: add link to OpenSSL Technical Policies

### DIFF
--- a/policies/sidebar.shtml
+++ b/policies/sidebar.shtml
@@ -4,7 +4,7 @@
     <h1><a href=".">Policies</a></h1>
     <ul>
       <li>
-	<a href="roadmap.html">Roadmap</a>
+        <a href="roadmap.html">Roadmap</a>
       </li>
       <li>
         <a href="trademark.html">Trademark Policy</a>
@@ -13,25 +13,25 @@
         <a href="platformpolicy.html">Platform Policy</a>
       </li>
       <li>
-	<a href="releasestrat.html">Release Strategy</a>
+        <a href="releasestrat.html">Release Strategy</a>
       </li>
       <li>
         <a href="travel.html">Travel Reimbursement Policy</a>.
       </li>
       <li>
-	<a href="secpolicy.html">Security Policy</a>
+        <a href="secpolicy.html">Security Policy</a>
       </li>
       <li>
-	<a href="omc-bylaws.html">OpenSSL Bylaws</a>
+        <a href="omc-bylaws.html">OpenSSL Bylaws</a>
       </li>
       <li>
-	<a href="otc-policies.html">OpenSSL Technical Policies</a>
+        <a href="otc-policies.html">OpenSSL Technical Policies</a>
       </li>
       <li>
         <a href="committers.html">Policy for Committers</a>
       </li>
       <li>
-	<a href="codingstyle.html">Coding Style</a>
+        <a href="codingstyle.html">Coding Style</a>
       </li>
       <li>
         <a href="cla.html">Contributor Agreements</a>

--- a/policies/sidebar.shtml
+++ b/policies/sidebar.shtml
@@ -25,6 +25,9 @@
 	<a href="omc-bylaws.html">OpenSSL Bylaws</a>
       </li>
       <li>
+	<a href="otc-policies.html">OpenSSL Technical Policies</a>
+      </li>
+      <li>
         <a href="committers.html">Policy for Committers</a>
       </li>
       <li>


### PR DESCRIPTION
**commit 1731c0b7c4668902a230158d4b78fe7d8622061a**
Author: Dr. Matthias St. Pierre <matthias.st.pierre@ncp-e.com>
Date:   Thu Oct 1 18:13:22 2020 +0200

    policies/sidebar: add link to OpenSSL Technical Policies

**commit 0a1a7e00f9b9c99434be863effe945d9e21f660d**
Author: Dr. Matthias St. Pierre <matthias.st.pierre@ncp-e.com>
Date:   Thu Oct 1 18:14:51 2020 +0200

    fixup! policies/sidebar: add link to OpenSSL Technical Policies



_(The fixup commit is optional and can be dropped if undesired. If you prefer, I could keep the whitespace cleanup (mixed indentation using tabs and spaces) as a  separate commit with the commit message: `policies/sidebar: whitespace cleanup`)_

