### PR TITLE
by laws: remove the necessity for the OMC to invite committers and OTC members.

### DIFF
--- a/policies/omc-bylaws.html
+++ b/policies/omc-bylaws.html
@@ -49,8 +49,9 @@
           <p>Committers also have a responsibility to review code submissions in
           accordance with OpenSSL project policies and procedures.</p>
 
-          <p>Commit access is granted as a result of a vote by the OMC. It may
-          be withdrawn at any time by a vote of the OMC.</p>
+          <p>Commit access is granted by invitation from the OTC and requires
+          a prior OMC vote of acceptance. It may be withdrawn at any time by
+          a vote of the OMC.</p>
 
           <p>A condition of commit access is that the committer has signed an
           Individual Contributor Licence Agreement (ICLA). If contributions may
@@ -221,10 +222,11 @@
             manner;</li>
           </ul>
 
-          <p>Membership of the OTC is by invitation only from the OMC.
-          OTC members must be committers and hence all rules that apply to committers also apply.
-          OTC members may be OMC members and in which case all rules that apply to OMC members
-          also apply.</p>
+          <p>Membership of the OTC is by invitation from the OTC and requires
+          a prior OMC vote of acceptance. OTC members must be committers and
+          hence all rules that apply to committers also apply.
+          OTC members may be OMC members and in which case all rules that apply
+          to OMC members also apply.</p>
 
           <p>The OTC makes technical decisions on behalf of the project based on
           requirements specified by the OMC. In order to have


### PR DESCRIPTION
It would be better if these invitations come from the OTC which does the nominations.

This requires an OMC by law vote which will be raised after reviews.
