### PR TITLE
bin/mk-notes: correct the anchor links to the CVE descriptions

### DIFF
--- a/bin/mk-notes
+++ b/bin/mk-notes
@@ -41,7 +41,7 @@ while ( <STDIN> ) {
 	    print "<ul>\n";
 	    $in_ul = 1;
 	}
-	s/CVE-(\d{4}-\d{4})/<a href=vulnerabilities.html#$1>CVE-$1<\/a>/g;
+	s/CVE-\d{4}-\d{4}/<a href=vulnerabilities.html#$&>$&<\/a>/g;
 	print;
     }
 }


### PR DESCRIPTION
I didn't test it, but from looking at the code it should fix the incorrectly generated anchor links on the [OpenSSL 1.1.1 Series Release Notes](https://www.openssl.org/news/openssl-1.1.1-notes.html) page.

- **wrong** https://www.openssl.org/news/vulnerabilities.html#2020-1971

- **correct** https://www.openssl.org/news/vulnerabilities.html#CVE-2020-1971

(Some notes.html pages probably need to be regenerated after merging this.)
