### PR TITLE
Fix style for links containing "raw"

### DIFF
--- a/inc/screen.css
+++ b/inc/screen.css
@@ -1369,7 +1369,7 @@ figure.code .highlight {
   border-bottom: 0;
 }
 
-.download-source, html a[href*=raw], figure.code figcaption a {
+.download-source, figure.code figcaption a {
   position: absolute;
   right: .8em;
   text-decoration: none;
@@ -1379,7 +1379,7 @@ figure.code .highlight {
   text-shadow: #cbcccc 0 1px 0;
   padding-left: 3em;
 }
-.download-source:hover, html a[href*=raw]:hover, figure.code figcaption a:hover {
+.download-source:hover, figure.code figcaption a:hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
The stylesheet contains rules that applies to all links to urls containing "raw". This applies to links to documentation for function
that contain this word, in such as `EVP_PKEY_new_raw_private_key`.

These rules seems to be otherwise unused, so removing them fixes the problem.