### PR TITLE
Fix bin/mk-manpages3 to handle spurious & in the description

### DIFF
--- a/bin/mk-manpages3
+++ b/bin/mk-manpages3
@@ -18,7 +18,7 @@ srcdir=tmp/doc/html
     $HERE/strip-man-html < $srcdir/$F > $destdir/$G
 
     section=$(basename $Dn | sed -e 's|^man||')
-    description="$($HERE/all-html-man-names < $destdir/$G | sed 's|^.* - ||')"
+    description="$($HERE/all-html-man-names < $destdir/$G | sed -e 's|^.* - ||' -e 's|\&|\\\&|g')"
     names="$($HERE/all-html-man-names < $destdir/$G | sed -e 's| - .*||' -e 's|, *| |g' -e 's|/|-|g')"
     for name in $names; do
         G=$Dn/$name.html


### PR DESCRIPTION
We have some pages that emit &lt; and &gt; in the NAMES description in
the HTML output.

However, we're using sed to massage a template with that description,
and & happens to be significant.  Therefore, it needs being explicitly
escaped.

Partially fixes openssl/openssl#13949