### PR TITLE
bin/mk-notes: adjust regular expression for CVE IDs

### DIFF
--- a/bin/mk-notes
+++ b/bin/mk-notes
@@ -41,7 +41,7 @@ while ( <STDIN> ) {
 	    print "<ul>\n";
 	    $in_ul = 1;
 	}
-	s/CVE-\d{4}-\d{4}/<a href=vulnerabilities.html#$&>$&<\/a>/g;
+	s/CVE-\d{4}-\d{4,}/<a href=vulnerabilities.html#$&>$&<\/a>/g;
 	print;
     }
 }


### PR DESCRIPTION
According to [1], the CVE ID can now have more than four digits,
which actually happened for the CVEs fixed by 1.1.1j.

[1] https://cve.mitre.org/about/faqs.html#cve_id_syntax_change


_(Note: https://www.openssl.org/news/openssl-1.1.1-notes.html needs to be regenerated.)_