### PR TITLE
Update security policy to note we prenotify projects like LibreSSL and BoringSSL

### DIFF
--- a/policies/secpolicy.html
+++ b/policies/secpolicy.html
@@ -12,7 +12,7 @@
 	  <header>
 	    <h2>Security Policy</h2>
 	    <h5>
-	      Last modified 2nd March 2021
+	      Last modified 16th March 2021
 	    </h5>
 	</header>
 	  <div class="entry-content">

--- a/policies/secpolicy.html
+++ b/policies/secpolicy.html
@@ -126,7 +126,7 @@
 	    that uses OpenSSL as included on
 	    <a
 	    href="http://oss-security.openwall.org/wiki/mailing-lists/distros">this list of Operating System distribution security contacts</a>.</li>
-            <li>We also include other open source projects that are based on OpenSSL which
+            <li>We also include other open source projects that are derived from OpenSSL which
             have a significant user base and a reciprocal arrangement. </li>
 	    <li>We may also include other organisations that are not listed but
 	    would otherwise qualify for list membership.  </li>

--- a/policies/secpolicy.html
+++ b/policies/secpolicy.html
@@ -12,7 +12,7 @@
 	  <header>
 	    <h2>Security Policy</h2>
 	    <h5>
-	      Last modified 12th May 2020
+	      Last modified 2nd March 2021
 	    </h5>
 	</header>
 	  <div class="entry-content">
@@ -126,6 +126,8 @@
 	    that uses OpenSSL as included on
 	    <a
 	    href="http://oss-security.openwall.org/wiki/mailing-lists/distros">this list of Operating System distribution security contacts</a>.</li>
+            <li>We also include other open source projects that are based on OpenSSL which
+            have a significant user base and a reciprocal arrangement. </li>
 	    <li>We may also include other organisations that are not listed but
 	    would otherwise qualify for list membership.  </li>
             <li>We may also include organisations with which we have a


### PR DESCRIPTION
Policy change, requires OMC vote.