### PR TITLE
Complete the transition changelog.txt -> changelog.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ docs/fips.inc
 docs/man*/
 news/changelog.html
 news/changelog.inc
-news/changelog.txt
+news/changelog.md
 news/cl*.txt
 news/newsflash.inc
 news/openssl-*-notes.html

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ news/$(1): $(CHECKOUTS)/$(2)
 	cp $$? $$@
 endef
 
-# Create the target 'news/changelog.txt', taking the source from
+# Create the target 'news/changelog.md', taking the source from
 # $(CHECKOUTS)/openssl/CHANGES.md
 $(eval $(call mknews_changelogtxt,changelog.md,openssl/CHANGES.md))
 

--- a/news/changelog.html.tt
+++ b/news/changelog.html.tt
@@ -22,8 +22,8 @@
             <p>
             This is the changelog for the master branch, the one that is
             currently in active development.
-	    The plain-text version of this document is available
-	    here: <a href="changelog.txt">changelog.txt</a>
+	    The plain-text / markdown version of this document is available
+	    here: <a href="changelog.md">changelog.md</a>
             </p>
 	    </p>
             For other branches, the changelogs are distributed with


### PR DESCRIPTION
Almost a year ago, in 4b0220368e888aab29972537aff8602a45b724e9, changelog.txt
was renamed to changelog.md.  It seems, however, that we didn't make that
change complete.