### PR TITLE
bin/mk-latest: Make the adapation for the OpenSSL 3.0 version scheme work

### DIFF
--- a/bin/mk-latest
+++ b/bin/mk-latest
@@ -42,9 +42,9 @@ print <<\EOF;
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^(openssl-0\.9\.\d.*) old/0.9.x/$1 [L]
 RewriteCond %{REQUEST_FILENAME} !-f
-RewriteRule ^(openssl-(\d+\.\d+\.\d+).*) old/$2/$1 [L]
+RewriteRule ^(openssl-3\.(\d+).*) old/3.$2/$1 [L]
 RewriteCond %{REQUEST_FILENAME} !-f
-RewriteRule ^(openssl-(\d+\.\d+).*) old/$2/$1 [L]
+RewriteRule ^(openssl-(\d+\.\d+\.\d+).*) old/$2/$1 [L]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^openssl-(fips.*)  old/fips/openssl-$1 [L]
 


### PR DESCRIPTION
The attempt done in the previous commit didn't quite work out.
Current fix is to hard code 3.x series.

Fixes #229