### PR TITLE
Reorder the old source directory list in source/old/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ $(foreach S,fips $(FUTURESERIES) $(SERIES) $(OLDSERIES2),$(eval $(call mkoldsour
 
 source/old/index.html: source/old/index.html.tt bin/from-tt
 	@rm -f $@
-	./bin/from-tt releases='fips $(FUTURESERIES) $(SERIES) $(OLDSERIES2)' $<
+	./bin/from-tt releases='$(FUTURESERIES) $(SERIES) $(OLDSERIES2) fips' $<
 
 # Because these the indexes of old tarballs will inevitably be newer
 # than the tarballs that are moved into their respective directory,

--- a/source/old/index.html.tt
+++ b/source/old/index.html.tt
@@ -11,7 +11,7 @@
         <div class="entry-content">
           <p>Here are the old releases.</p>
           <ul>
-[% FOREACH release IN releases.split('\s+').reverse -%]
+[% FOREACH release IN releases.split('\s+') -%]
             <li><a href="[% release %]">[% release %]</a></li>
 [% END -%]
           </ul>


### PR DESCRIPTION
Change the template source/old/index.html.tt to not reverse the
received list of releases.

Change the order of releases to that template to be from newest to
oldest, and fips (the old FOM) last.

Fixes #235