### PR TITLE
platform policy: add new targets

### DIFF
--- a/policies/releasestrat.html
+++ b/policies/releasestrat.html
@@ -88,6 +88,11 @@
 	  fixes. Before that, bug and security fixes will be applied
 	  as appropriate.</p>
 
+          <p>The addition of new platforms to LTS branches is acceptable so
+          long as the required changes do not modify the C source code and
+          are deemed low risk by the OTC.
+          </p>
+
 	  <hr />
 
 	  <p>

--- a/policies/releasestrat.html
+++ b/policies/releasestrat.html
@@ -89,7 +89,7 @@
 	  as appropriate.</p>
 
           <p>The addition of new platforms to LTS branches is acceptable so
-          long as the required changes do not modify the C source code and
+          long as the required changes do not modify the source code and
           are deemed low risk by the OTC.
           </p>
 


### PR DESCRIPTION
If a new target doesn't modify the C sources and is considered low risk, it can be added to LTS releases.

This will require an OMC vote but it is being raised here for discussion.