### PR TITLE
platform policy: add new targets

### DIFF
--- a/policies/releasestrat.html
+++ b/policies/releasestrat.html
@@ -88,6 +88,10 @@
 	  fixes. Before that, bug and security fixes will be applied
 	  as appropriate.</p>
 
+          <p>The addition of new platforms to LTS branches is acceptable so
+          long as the required changes consist solely of additions to
+          configuration.</p>
+
 	  <hr />
 
 	  <p>


### PR DESCRIPTION
Allow platforms that add but do not otherwise modify configuration to be added to LTS releases.

This will require an OMC vote but it is being raised here for discussion.