### PR TITLE
Update migration guide link in source/index.html

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -51,7 +51,7 @@
         <a href="https://www.openssl.org/docs/manmaster/man7/crypto.html">manual page</a>.
         Information and notes about migrating existing applications to OpenSSL
         3.0 are available in the
-        <a href="https://www.openssl.org/docs/manmaster/man7/migration_guide.html">OpenSSL 3.0 Migration Guide</a></p>
+        <a href="https://github.com/openssl/openssl/blob/master/doc/man7/migration_guide.pod">OpenSSL 3.0 Migration Guide</a></p>
 	    <table>
 	      <tr>
 		<td>KBytes&nbsp;</td>


### PR DESCRIPTION
To fix the "404 Not Found" error reported at

- https://github.com/openssl/openssl/issues/16152