### PR TITLE
update newsflash for 3.0.0

### DIFF
--- a/news/newsflash.txt
+++ b/news/newsflash.txt
@@ -5,6 +5,7 @@
 # headings.  URL paths must all be absolute.
 Date: Item
 
+07-Sep-2021: Final version of OpenSSL 3.0.0 is now available: please download and upgrade!
 24-Aug-2021: <a href="/news/secadv/20210824.txt">Security Advisory</a>: two security fixes
 24-Aug-2021: OpenSSL 1.1.1l is now available, including bug and security fixes
 29-Jul-2021: Beta 2 of OpenSSL 3.0 is now available. This is a release candidate: please download and test it


### PR DESCRIPTION
- Update newsflash for OpenSSL 3.0.0
