### PR TITLE
Update the secondary platform definition

### DIFF
--- a/policies/platformpolicy.html
+++ b/policies/platformpolicy.html
@@ -29,8 +29,9 @@
 		</dd>
 		<dt>Secondary</dt>
 		<dd>
-		  Targets which at least one team member actively
-		  supports.<br>
+		  Targets which at least one team member actively supports, or the
+		  platform is covered by CI and at least one team member has access to
+		  the platform.<br>
 
 		  <em>The current secondary development platforms
 		    are: FreeBSD, Windows (Visual Studio, MinGW), MacOS


### PR DESCRIPTION
Updates to the definition as per an OMC vote:

topic: Amend the secondary platform criteria in the platform policy to say:
   "Targets which at least one team member actively supports, or the platform
    is covered by CI and at least one team member has access to the platform"

accepted:  yes  (for: 5, against: 0, abstained: 0, not voted: 0)