### PR TITLE
bin/mk-latest: Treat post 1.x.x releases right

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ $(eval $(call mknews_vulnerability,-$(S),-b $(S))))
 
 source/.htaccess: $(wildcard source/openssl-*.tar.gz) bin/mk-latest
 	@rm -f @?
-	./bin/mk-latest source >$@
+	./bin/mk-latest $(RELEASEDIR) >$@
 source/index.inc: $(wildcard $(RELEASEDIR)/openssl-*.tar.gz) bin/mk-filelist
 	@rm -f $@
 	./bin/mk-filelist $(RELEASEDIR) '' 'openssl-*.tar.gz' >$@

--- a/bin/mk-latest
+++ b/bin/mk-latest
@@ -12,7 +12,8 @@ my @tarballs =
 
 my %series = ();
 foreach(@tarballs) {
-	my ($version, $serie) = /^openssl-((\d+\.\d+\.\d+)[a-z]*)\./;
+    my ($version, $serie) =
+        /^openssl-(?|(([01]\.\d+\.\d+)[a-z]*)|((\d+\.\d+)\.\d+))\./;
 	$series{$serie} = $_;
 }
 my $latest = $series{ (reverse sort keys %series)[0] };


### PR DESCRIPTION
The currently produced .htaccess has this RewriteRule

    RewriteRule ^openssl-3.0.0-latest.tar.gz$ openssl-3.0.0.tar.gz [L,R=302,NC]

It should really be this:

    RewriteRule ^openssl-3.0-latest.tar.gz$ openssl-3.0.0.tar.gz [L,R=302,NC]

Also, since all other scripts that handle our tarballs are passed
$(RELEASEDIR), not just 'source', so should this one.
