### PR TITLE
Drop source/snapshot/README

### DIFF
--- a/source/snapshot/README
+++ b/source/snapshot/README
@@ -1,4 +1,0 @@
-These daily snapshots of the source tree are provided for convenience
-only and not even guaranteed to compile.  Note that keeping a git local
-repository and updating it every 24 hours is equivalent and will often be
-faster and more efficient.


### PR DESCRIPTION
This file isn't used any more, since source/snapshot is now aliased to
$ftp/snapshot.
This README has been copied to $ftp/snapshot/.message, which is
configured as HeaderName in the system Apache configuration, and is
thus shown directly in the snapshot directory listing.
