### PR TITLE
move solaris64 platforms from Unadopted to Community category

### DIFF
--- a/policies/platformpolicy.html
+++ b/policies/platformpolicy.html
@@ -418,7 +418,51 @@
                     <td>&nbsp;&nbsp;</td>
                     <td>@rsbeckerca</td>
                   </tr>
-                </table>
+                  <tr>
+                    <td>solaris64-x86_64-gcc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Solaris</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>x86_64</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>gcc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>@orcl-jlana @cernoseka</td>
+                  </tr>
+                  <tr>
+                    <td>solaris64-x86_64-cc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Solaris</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>x86_64</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Sun C</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>@orcl-jlana @cernoseka</td>
+                  </tr>
+                  <tr>
+                    <td>solaris64-sparcv9-gcc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Solaris</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Sparc V9 64 bit</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>gcc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>@orcl-jlana @cernoseka</td>
+                  </tr>
+                  <tr>
+                    <td>solaris64-sparcv9-cc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Solaris</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Sparc V9 64 bit</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Sun C</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>@orcl-jlana @cernoseka</td>
+                  </tr>
+                 </table>
               </p>
               <p>
                 The current unadopted platforms are:
@@ -452,24 +496,6 @@
                     <td>gcc</td>
                   </tr>
                   <tr>
-                    <td>solaris64-x86_64-gcc</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Solaris</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>x86_64</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>gcc</td>
-                  </tr>
-                  <tr>
-                    <td>solaris64-x86_64-cc</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Solaris</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>x86_64</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Sun C</td>
-                  </tr>
-                  <tr>
                     <td>solaris-sparcv7-gcc</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>Solaris</td>
@@ -493,15 +519,6 @@
                     <td>Solaris</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>Sparc V9 32 bit</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>gcc</td>
-                  </tr>
-                  <tr>
-                    <td>solaris64-sparcv9-gcc</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Solaris</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Sparc V9 64 bit</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>gcc</td>
                   </tr>
@@ -532,16 +549,7 @@
                     <td>&nbsp;&nbsp;</td>
                     <td>Sun C</td>
                   </tr>
-                  <tr>
-                    <td>solaris64-sparcv9-cc</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Solaris</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Sparc V9 64 bit</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Sun C</td>
-                  </tr>
-                  <tr>
+                 <tr>
                     <td>irix-mips3-gcc</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>Irix 6.x</td>


### PR DESCRIPTION
The Solaris 64bit platforms meet the Community support criteria.