### PR TITLE
added solaris64 platforms maintainers

### DIFF
--- a/policies/platformpolicy.html
+++ b/policies/platformpolicy.html
@@ -451,6 +451,50 @@
                     <td>&nbsp;&nbsp;</td>
                     <td>@pkubaj</td>
                   </tr>
+                  <tr>
+                    <td>solaris64-x86_64-gcc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Solaris</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>x86_64</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>gcc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>@orcl-jlana @cernoseka</td>
+                  </tr>
+                  <tr>
+                    <td>solaris64-x86_64-cc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Solaris</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>x86_64</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Sun C</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>@orcl-jlana @cernoseka</td>
+                  </tr>
+                  <tr>
+                    <td>solaris64-sparcv9-gcc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Solaris</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Sparc V9 64 bit</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>gcc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>@orcl-jlana @cernoseka</td>
+                  </tr>
+                  <tr>
+                    <td>solaris64-sparcv9-cc</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Solaris</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Sparc V9 64 bit</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Sun C</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>@orcl-jlana @cernoseka</td>
+                  </tr>
                 </table>
               </p>
               <p>
@@ -485,24 +529,6 @@
                     <td>gcc</td>
                   </tr>
                   <tr>
-                    <td>solaris64-x86_64-gcc</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Solaris</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>x86_64</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>gcc</td>
-                  </tr>
-                  <tr>
-                    <td>solaris64-x86_64-cc</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Solaris</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>x86_64</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Sun C</td>
-                  </tr>
-                  <tr>
                     <td>solaris-sparcv7-gcc</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>Solaris</td>
@@ -530,15 +556,6 @@
                     <td>gcc</td>
                   </tr>
                   <tr>
-                    <td>solaris64-sparcv9-gcc</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Solaris</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Sparc V9 64 bit</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>gcc</td>
-                  </tr>
-                  <tr>
                     <td>solaris-sparcv7-cc</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>Solaris</td>
@@ -562,15 +579,6 @@
                     <td>Solaris</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>Sparc V9 32 bit</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Sun C</td>
-                  </tr>
-                  <tr>
-                    <td>solaris64-sparcv9-cc</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Solaris</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Sparc V9 64 bit</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>Sun C</td>
                   </tr>


### PR DESCRIPTION
We maintain the  Solaris 64bit platforms. I added the maintainers and moved them from the Unsupported to the Community category.
