### PR TITLE
fips: remove the mention of the FIPS object module for 1.0.2.

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -52,10 +52,6 @@
         3.0 are available in the
         <a href="https://www.openssl.org/docs/man3.0/man7/migration_guide.html">OpenSSL 3.0 Migration Guide</a></p>
 
-        <p>The OpenSSL FIPS Object Module (FOM) 2.0 is also available for
-        download. It is no longer receiving updates. It must be used in
-        conjunction with a FIPS capable version of OpenSSL (1.0.2 series).</p>
-
 	    <table>
 	      <tr>
 		<td>KBytes&nbsp;</td>


### PR DESCRIPTION
We don't advertise 1.0.2 apart from in the old heirarchy.  It's seems relevant
to also not advertise the corresponding FOM.

We also need to update the script that produces `index.inc`.