### PR TITLE
Add the 3.0 supported until date to the download page

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -30,13 +30,13 @@
 	    A list of mirror sites can be found <a href="mirror.html">here</a>.
 	    </p>
 
-	    <p><em>Note:</em> The latest stable version is the 3.0 series. Also
-        available is the 1.1.1 series which is our Long Term Support (LTS)
-        version, supported until 11th September 2023. All older versions
-        (including 1.1.0, 1.0.2, 1.0.0 and 0.9.8) are now out of support and
-        should not be used. Users of these older versions are encouraged to
-        upgrade to 3.0 or 1.1.1 as soon as possible. Extended support
-        for 1.0.2 to gain access to security fixes for that version is
+        <p><em>Note:</em> The latest stable version is the 3.0 series supported
+        until 7th September 2023. Also available is the 1.1.1 series which is
+        our Long Term Support (LTS) version, supported until 11th September
+        2023. All older versions (including 1.1.0, 1.0.2, 1.0.0 and 0.9.8) are
+        now out of support and should not be used. Users of these older versions
+        are encouraged to upgrade to 3.0 or 1.1.1 as soon as possible. Extended
+        support for 1.0.2 to gain access to security fixes for that version is
         <a href="/support/contracts.html">available</a>.</p>
 
         <p>OpenSSL 3.0 is the latest major version of OpenSSL. The OpenSSL FIPS


### PR DESCRIPTION
This will then mean the download page contains all of the same supported
until dates as available on the current release stategy page. Future
policies should explain how the support periods are calculated, but the
actual dates will be external to the policy.