### PR TITLE
Replace technical policies with reference to GitHub repository

### DIFF
--- a/policies/otc-policies.html
+++ b/policies/otc-policies.html
@@ -13,40 +13,17 @@
           <h2>OpenSSL Technical Policies</h2>
           <h5>
             First issued 30th September 2020<br/>
-            Last modified 30th September 2020
+            Moved to GitHub Nov 2021
           </h5>
         </header>
 
         <div class="entry-content">
 
-          <p>This document lists the technical policies and procedures established
-          by the OTC in accordance with the <a href="omc-bylaws.html">project bylaws</a>
-          and the requirements specified by the OMC.</p>
-
-          <h3><a name="voting-procedure">Voting Procedure</a></h3>
-
-          The following regulations complement the
-          <a href="omc-bylaws.html#otc-voting">OTC Voting Procedures</a>
-          stated in the project bylaws:
-
-          <p>The proposer of a vote is ultimately responsible for updating the
-          <a href="https://git.openssl.org/?p=otc.git;f=votes.txt;hb=HEAD">votes.txt</a>
-          file in the <a href="https://git.openssl.org/?p=otc.git">OTC Git repository</a>.
-          Outside of a face to face meeting, voters MUST reply to the vote email indicating
-          their preference and optionally their reasoning.  Voters MAY update the votes.txt
-          file in addition.</p>
-
-          <p>The proposed vote text SHOULD be raised for discussion before calling the vote.</p>
-
-          <p>Public votes MUST be called on the project list, not the OTC list and the
-          subject MUST begin with “VOTE:”.  Private votes MUST be called on the
-          OTC list with “PRIVATE VOTE:” beginning subject.</p>
-
-      <h2><a name="update">Update History</a></h2>
-      <ul>
-        <li>30-September-2020.
-        Initial revision.</li>
-      </ul>
+          <p>The technical policies and procedures established by the OTC
+            in accordance with the <a href="omc-bylaws.html">project bylaws</a>
+            are now maintained in the
+            <a href="https://github.com/openssl/technical-policies">openssl/technical-policies</a>
+            repository on GitHub.</p>
 
         </div>
         <footer>


### PR DESCRIPTION
This pull request completes an outstanding action item from the OTC meetings, see [minutes-2022-01-11](https://github.com/openssl/otc/blob/master/meeting-minutes/minutes-2022-01-11.txt#L52). It depends on https://github.com/openssl/technical-policies/pull/29 which should get merged first.



