### PR TITLE
Communicate 3.0 as an LTS release

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -31,13 +31,13 @@
 	    </p>
 
         <p><em>Note:</em> The latest stable version is the 3.0 series supported
-        until 7th September 2023. Also available is the 1.1.1 series which is
-        our Long Term Support (LTS) version, supported until 11th September
-        2023. All older versions (including 1.1.0, 1.0.2, 1.0.0 and 0.9.8) are
-        now out of support and should not be used. Users of these older versions
-        are encouraged to upgrade to 3.0 or 1.1.1 as soon as possible. Extended
-        support for 1.0.2 to gain access to security fixes for that version is
-        <a href="/support/contracts.html">available</a>.</p>
+        until 7th September 2026. This is also a Long Term Support (LTS) version.
+        The previous LTS version (the 1.1.1 series) is also available and is
+        supported until 11th September 2023. All older versions (including 1.1.0,
+        1.0.2, 1.0.0 and 0.9.8) are now out of support and should not be used.
+        Users of these older versions are encouraged to upgrade to 3.0 as soon
+        as possible. Extended support for 1.0.2 to gain access to security fixes
+        for that version is <a href="/support/contracts.html">available</a>.</p>
 
         <p>OpenSSL 3.0 is the latest major version of OpenSSL. The OpenSSL FIPS
         Object Module (FOM) 3.0 is an integrated part of the OpenSSL 3.0


### PR DESCRIPTION
OMC voted to make 3.0 the next LTS release:

https://github.com/openssl/general-policies/issues/9

Therefore we communicate that on the download page.