### PR TITLE
Fix the supported to date for 3.0 and tag it as LTS

### DIFF
--- a/policies/releasestrat.html
+++ b/policies/releasestrat.html
@@ -70,7 +70,7 @@
 	  project has adopted the following policy:</p>
 
 	  <ul>
-	    <li>Version 3.0 will be supported until 2023-09-07.</li>
+	    <li>Version 3.0 will be supported until 2026-09-07 (LTS).</li>
 	    <li>Version 1.1.1 will be supported until 2023-09-11 (LTS).</li>
 	    <li>Version 1.0.2 is no longer supported. Extended support
 	    for 1.0.2 to gain access to security fixes for that version is


### PR DESCRIPTION
This got missed when announcing 3.0 as LTS.