### PR TITLE
Extend the primary platforms list

### DIFF
--- a/policies/platformpolicy.html
+++ b/policies/platformpolicy.html
@@ -103,6 +103,33 @@
                     <td>gcc 9.3.0</td>
                   </tr>
                   <tr>
+                    <td>linux-generic64</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Ubuntu Server 20.04.3</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>x86_64</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>gcc 9.3.0</td>
+                  </tr>
+                  <tr>
+                    <td>linux-x86</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Debian 11.2</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>x86</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>gcc 11.2.0</td>
+                  </tr>
+                  <tr>
+                    <td>linux-generic32</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>Debian 11.2</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>x86</td>
+                    <td>&nbsp;&nbsp;</td>
+                    <td>gcc 11.2.0</td>
+                  </tr>
+                  <tr>
                     <td>BSD-x86_64</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>FreeBSD 13.0</td>
@@ -834,15 +861,6 @@
                     <td>Linux</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>riscv64</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>gcc</td>
-                  </tr>
-                  <tr>
-                    <td>linux-x86</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>Linux</td>
-                    <td>&nbsp;&nbsp;</td>
-                    <td>x86</td>
                     <td>&nbsp;&nbsp;</td>
                     <td>gcc</td>
                   </tr>


### PR DESCRIPTION
Add linux-x86, linux-generic32 and linux-generic64 as primary
platforms. For linux-generic64 I am proposing this to be on
Ubuntu 20.04.3 for consistency with the linux-x86_64 target. For
the 32 bit builds I am proposing Debian 11.2 since Ubuntu does not
appear to have a 32 bit version.

This implements the vote in openssl/general-policies#12