### PR TITLE
Add Paul Dale and Tomas Mraz as possible release managers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ community/committers.inc: $(PERSONDB)
 	@rm -f Members
 
 community/otc.inc: $(PERSONDB)
-	./bin/mk-omc -n -t 'OTC Members' otc otc-inactive > $@
+	./bin/mk-omc -n -p -t 'OTC Members' otc otc-inactive > $@
 community/omc.inc: $(PERSONDB)
 	./bin/mk-omc -n -e -l -p -t 'OMC Members' omc omc-inactive > $@
 community/omc-alumni.inc: $(PERSONDB)

--- a/source/index.html
+++ b/source/index.html
@@ -71,9 +71,9 @@
         post a question there.</p>
 
 	    <p>PGP keys for the signatures are available from the
-	    <a href="https://www.openssl.org/community/omc.html">OMC page</a>.
-	    Current members that sign releases include Richard Levitte and
-	    Matt Caswell.
+	    <a href="https://www.openssl.org/community/omc.html">OTC page</a>.
+	    Current members that sign releases include Richard Levitte,
+	    Matt Caswell, Paul Dale, and Tomas Mraz. </p>
 
 	    <p>
 	    Each day we make a snapshot of each development branch.


### PR DESCRIPTION
Also refer to the OTC page for list of PGP keys which requires
the list to include PGP keys if specified in the persondb.