### PR TITLE
Fix the link to the OTC page

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -71,7 +71,7 @@
         post a question there.</p>
 
 	    <p>PGP keys for the signatures are available from the
-	    <a href="https://www.openssl.org/community/omc.html">OTC page</a>.
+	    <a href="https://www.openssl.org/community/otc.html">OTC page</a>.
 	    Current members that sign releases include Richard Levitte,
 	    Matt Caswell, Paul Dale, and Tomas Mraz. </p>
 


### PR DESCRIPTION
Fixes a mistake from #321 