### PR TITLE
fix vulnerability ranges on version page for OpenSSL 3+

### DIFF
--- a/bin/vulnxml2jsonproject.py
+++ b/bin/vulnxml2jsonproject.py
@@ -31,6 +31,12 @@ def merge_affects(issue,base):
        else:
           alist[-1].append(ver)
        prev = ver
+       parts = ver.split('.')
+       # Deal with 3.0 version scheme
+       if int(parts[0])>=3:
+           anext = '.'.join(parts[:-1])+'.'+str(int(parts[-1])+1)
+           continue
+       # Deal with pre 3.0 version scheme
        if (str.isdigit(ver[-1])):   # First version after 1.0.1 is 1.0.1a
            anext = ver + "a"
        elif (ver[-1] == "y"):


### PR DESCRIPTION
"Fixed in OpenSSL 3.0.3 (git commit) (Affected 3.0.0,3.0.1,3.0.2)" 
should be 
"Fixed in OpenSSL 3.0.3 (git commit) (Affected 3.0.0-3.0.2)"