### PR TITLE
Two minor fixes to vulnerability parsing

### DIFF
--- a/bin/vulnxml2jsonproject.py
+++ b/bin/vulnxml2jsonproject.py
@@ -33,9 +33,12 @@ def merge_affects(issue,base):
        prev = ver
        parts = ver.split('.')
        # Deal with 3.0 version scheme
-       if int(parts[0])>=3:
-           anext = '.'.join(parts[:-1])+'.'+str(int(parts[-1])+1)
-           continue
+       try:
+           if int(parts[0])>=3:
+               anext = '.'.join(parts[:-1])+'.'+str(int(parts[-1])+1)
+               continue
+       except:
+           pass
        # Deal with pre 3.0 version scheme
        if (str.isdigit(ver[-1])):   # First version after 1.0.1 is 1.0.1a
            anext = ver + "a"

--- a/news/vulnerabilities.xml
+++ b/news/vulnerabilities.xml
@@ -3594,7 +3594,7 @@ issue.
     <affects base="1.0.2" version="1.0.2c"/>
     <affects base="1.0.2" version="1.0.2d"/>
     <affects base="1.0.2" version="1.0.2e"/>
-    <fixed base="1.0.2" version="1.0.2f" date="2016-0701"/>
+    <fixed base="1.0.2" version="1.0.2f" date="20160128"/>
 
     <description>
       Historically OpenSSL usually only ever generated DH parameters based on "safe"


### PR DESCRIPTION
There's a single vulnerability where we use fips as the version, don't fail on that.  Also fix up a bad date in vulnerabilities.xml where it copied the CVE name by mistake

