### PR TITLE
Diverse small fixes

### DIFF
--- a/inc/pandoc-body-epilogue.html5
+++ b/inc/pandoc-body-epilogue.html5
@@ -2,10 +2,10 @@
                     You are here:
 $if(breadcrumbs)$
                     $breadcrumbs$
-$endif$
 $if(is-index)$
 $else$
-                    : <a href="">$title$</a>
+                    : <a href="">$breadcrumb$</a>
+$endif$
 $endif$
                     <br/><a href="$top$sitemap.txt">Sitemap</a>
                 </footer>

--- a/inc/screen.css
+++ b/inc/screen.css
@@ -1569,10 +1569,10 @@ body > footer p:last-child {
 /* OPENSSL WEBSITE ADDITIONS */
 
 /* newsflash table */
-table > tr:first-child, table > thead {
+table > tr:first-child, table > thead, table > :not(thead + tbody) > tr:first-child {
     font-weight: bold; border-bottom: 1px solid black;
 }
-table > tr:nth-child(even), table > tbody > tr:nth-child(odd) {
+table > tr:nth-child(even), table > thead + tbody > tr:nth-child(odd), table > :not(thead + tbody) > tr:nth-child(even) {
     background-color: #D9f0ff;
 }
 td.d { float: left; width: 20%; }

--- a/inc/screen.css
+++ b/inc/screen.css
@@ -1569,8 +1569,12 @@ body > footer p:last-child {
 /* OPENSSL WEBSITE ADDITIONS */
 
 /* newsflash table */
-tr:first-child { font-weight: bold; border-bottom: 1px solid black; }
-tr:nth-child(even) { background-color: #D9f0ff; }
+table > tr:first-child, table > thead {
+    font-weight: bold; border-bottom: 1px solid black;
+}
+table > tr:nth-child(even), table > tbody > tr:nth-child(odd) {
+    background-color: #D9f0ff;
+}
 td.d { float: left; width: 20%; }
 td.t { float: right; width: 80%; }
 


### PR DESCRIPTION
- Replace `$title$` with `$breadcrumb$` in `inc/pandoc-body-epilogue.html5`,
  'cause that's actually how it is used.  They avoids interference from
  pandoc, which has ideas of its own what `$title$` should be used for.
- Alter the CSS for tables to work with different ways of wring them.
  That makes these three selectors equivalent:

      table > tr:first-child
      table > thead
      table > :not(thead + tbody) > tr:first-child

  That also makes these three selectors equivalent:

      table > tr:nth-child(even)
      table > thead + tbody > tr:nth-child(odd)
      table > :not(thead + tbody) > tr:nth-child(even)
