### PR TITLE
Fix problems with newer pandoc versions

### DIFF
--- a/bin/md-to-html5
+++ b/bin/md-to-html5
@@ -170,7 +170,7 @@ for f in "$@"; do
 	cd $dir
 	pandoc -t html5 -f markdown --template="$template" \
                --highlight-style="$highlightstyle" \
-               --tab-stop=8 --base-header-level=2 \
+               --tab-stop=8 --shift-heading-level-by=1 \
                -M author-meta='OpenSSL Foundation, Inc.' \
                -M lang=en \
 	       -M pagetitle="$title" \


### PR DESCRIPTION
Pandoc absolutely wants a styles.html alongside the HTML5 template, so
we give it one that's empty.

Also, --base-header-level is deprecated and should be replaced with
--shift-heading-level-by.  The pandoc documentation gives us this
formula:

    Use --shift-heading-level-by=X instead, where X = NUMBER - 1
