### PR TITLE
Restore the FAQ accordion functionality

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,13 @@
 ---
 breadcrumb: Frequently Asked Questions
+header-includes: |
+  <script>
+  $(function(){
+    $(".faq ul > li").click(function(){
+      $(this).toggleClass("open");
+    });
+  });
+  </script>
 ---
 # Frequently Asked Questions
 


### PR DESCRIPTION
When converting docs/faq.html to faq.md, the little scriptlet that
enabled the FAQ answer accordion functionality was lost, making it
impossible to expand the answers.

This restores that functionality.
