### PR TITLE
support/acks.md: Remove "current" link

### DIFF
--- a/support/acks.md
+++ b/support/acks.md
@@ -7,7 +7,7 @@ The OpenSSL project depends on volunteer efforts and financial support
 from the end user community. That support comes in [many
 forms](donations.html).
 
-## <a href="current">Sponsorship Donations</a>
+## Sponsorship Donations
 
 We would like to identify and thank the following sponsors for their
 donations which give significant support to the OpenSSL project. Please


### PR DESCRIPTION
Originally (when this file was still raw HTML), this was an ID
(`<h3 id="current">Sponsorship Donations</h3>`).  Turning it into a link
was a clear typo.

As far as I can tell, nothing linked to acks.html#current, so we can
as well drop it entirely.

Fixes #371
