### PR TITLE
Move CVE handling to use JSON files instead of vulnerability.xml, move to JSONv5 schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,10 +470,6 @@ news/newsflash.inc: $(OMCDATA)/newsflash.txt Makefile
 	    -e 's@: @</td><td class="t">@' \
 	    -e 's@$$@</td></tr>@'
 
-# Make sure we have a copy of vulnerabilities.xml among our public web files
-news/vulnerabilities.xml: $(OMCDATA)/vulnerabilities.xml
-	cp $< $@
-
 # mknews_vulnerability creates two targets and rulesets for creating
 # vulnerability lists for each release.  One target is to create a wrapping
 # HTML file from a template, the other is to create the inclusion file with
@@ -481,9 +477,9 @@ news/vulnerabilities.xml: $(OMCDATA)/vulnerabilities.xml
 #
 # $(1) = output file mod, $(2) = release version switch, $(3) = release version
 define mknews_vulnerability
-news/vulnerabilities$(1).inc: bin/mk-cvepage news/vulnerabilities.xml Makefile
+news/vulnerabilities$(1).inc: bin/cvejsontohtml.py news/secjson Makefile
 	@rm -f $$@
-	./bin/mk-cvepage -i news/vulnerabilities.xml $(2) > $$@
+	python3 ./bin/cvejsontohtml.py -i news/secjson $(2) > $$@
 news/vulnerabilities$(1).md: news/vulnerabilities.md.tt bin/from-tt Makefile
 	@rm -f $$@
 	./bin/from-tt -d news vulnerabilitiesinc='vulnerabilities$(1).inc' < $$< > $$@

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ SIMPLE = $(H_TOP) \
 	 $(H_NEWS) \
 	 news/newsflash.inc \
 	 news/secadv \
+	 news/secjson \
 	 news/vulnerabilities.inc \
 	 news/vulnerabilities.html \
 	 $(foreach S,$(SERIES) $(OLDSERIES),news/vulnerabilities-$(S).inc) \
@@ -512,14 +513,31 @@ news/secadv/$(1): $(OMCDATA)/secadv/$(1)
 	cp $$< $$@
 endef
 
+# mknews_secjson creates a target to copy a security json file from $(OMCDATA)/vulnerabilities-json
+# to news/secjson/.
+# $(1) = file name
+define mknews_secjson
+news/secjson/$(1): $(OMCDATA)/vulnerabilities-json/$(1)
+	cp $$< $$@
+endef
+
 # Get the set of files in $(OMCDATA)/secadv/
 SECADV_FILES = $(shell cd $(OMCDATA)/secadv/; git ls-files)
 $(foreach F,$(SECADV_FILES),$(eval $(call mknews_secadv,$(F))))
+
+# Get the set of files in $(OMCDATA)/vulnerabilities-json/
+SECJSON_FILES = $(shell cd $(OMCDATA)/vulnerabilities-json/; git ls-files)
+$(foreach F,$(SECJSON_FILES),$(eval $(call mknews_secjson,$(F))))
 
 mkdirnews_secadv: FORCE
 	mkdir -p news/secadv
 news/secadv: mkdirnews_secadv $(addprefix news/secadv/,$(SECADV_FILES))
 .PHONY: news/secadv mkdirnews_secadv
+
+mkdirnews_secjson: FORCE
+	mkdir -p news/secjson
+news/secjson: mkdirnews_secjson $(addprefix news/secjson/,$(SECJSON_FILES))
+.PHONY: news/secjson mkdirnews_secjson
 
 ######################################################################
 ##

--- a/bin/cvejsontohtml.py
+++ b/bin/cvejsontohtml.py
@@ -130,7 +130,12 @@ for k,cve in sorted(entries.items(), reverse=True):
     # Credits
     if ("credits" in cna):
         for credit in cna["credits"]:
-            allissues += " Reported by "+credit["value"]+"."
+            creditprefix = " Reported by "
+            if "type" in credit and "remediation dev" in credit["type"]:
+                creditprefix = " Fix developed by "
+            elif "type" in credit and "finder" not in credit["type"]:
+                creditprefix = " Thanks to "
+            allissues += creditprefix+credit["value"]+"."
 
     affects = []
     product = cna["affected"][0]

--- a/bin/cvejsontohtml.py
+++ b/bin/cvejsontohtml.py
@@ -13,7 +13,6 @@ import sys
 parser = OptionParser()
  
 parser.add_option("-b","--base",help="major version to filter on",dest="base")
-parser.add_option("-e","--extratext",help="extra text to add to description",dest="extratext")
 parser.add_option("-i","--inputdirectory",help="directory of json files",dest="directory")
 (options,args) = parser.parse_args()
 

--- a/bin/cvejsontohtml.py
+++ b/bin/cvejsontohtml.py
@@ -88,9 +88,10 @@ for k,cve in sorted(entries.items(), reverse=True):
 
     # Advisory (use the title instead of openssl advisory)
     title= "(OpenSSL Advisory)"
+    refs = ""
     if "title" in cna:
         title = cna['title']
-    refs = title
+        refs = title
     for ref in cna["references"]:
         if "tags" in ref:
             if "vendor-advisory" in ref["tags"]:

--- a/bin/cvejsontohtml.py
+++ b/bin/cvejsontohtml.py
@@ -1,0 +1,139 @@
+import json
+import os
+import re
+import xml.sax.saxutils as saxutils 
+from optparse import OptionParser
+parser = OptionParser()
+ 
+parser.add_option("-v","--version",help="major version to filter on",dest="filterversion")
+parser.add_option("-e","--extratext",help="extra text to add to description",dest="extratext")
+parser.add_option("-i","--inputdirectory",help="directory of json files",dest="directory")
+(options,args) = parser.parse_args()
+
+
+def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
+    return [int(text) if text.isdigit() else text.lower()
+            for text in _nsre.split(s)]   
+            
+filterversion = options.filterversion or ""
+cves = []
+entries = {}
+
+for x in os.listdir(options.directory or "./"):
+    if x.endswith(".json"):
+        try:
+            fd = open(options.directory+x)
+            cve = json.load(fd)
+            cves.append(cve)
+        except:
+            print ("Ignoring due to error parsing: "+options.directory+x)
+            continue
+
+# Filter on version 
+# We want to sort on reverse date then cve name
+for cve in cves:
+    cna = cve["containers"]["cna"]
+    cveid = cve["cveMetadata"]["cveId"]
+    for version in cna["affected"][0]["versions"]:
+       fixedin = version["version"]
+       if (fixedin.startswith(filterversion)):
+           datepublic = cna["datePublic"]+"-"+cveid
+           entries[datepublic]=cve
+
+lastfixedv = ""
+productname = ""
+sections = []
+lastyear = ""
+for k,cve in sorted(entries.items(), reverse=True):
+    year = k.split('-')[0]
+
+    if (lastyear != year):
+        print("<h1>"+year+"</h1>")
+        lastyear = year
+
+    cna = cve["containers"]["cna"]
+    e = {}
+    e['cveid'] = cve["cveMetadata"]["cveId"]
+
+    # CVE name
+    print("<a href=\"https://cve.org/CVERecord?id="+e['cveid']+"\">"+e['cveid']+"</a>")
+
+    # Advisory (use the title instead of openssl advisory)
+    title= "(OpenSSL Advisory)"
+    if "title" in cna:
+        title = cna['title']
+    refs = title
+    for ref in cna["references"]:
+        if "tags" in ref:
+            if "vendor-advisory" in ref["tags"]:
+                url = ref["url"]
+                refs = "<a href=\""+url+"\">"+title+"</a>"
+    print (" "+refs)
+
+    # Impact
+    for metric in cna["metrics"]:
+        if "other" in metric["format"]:
+            impact = metric["other"]["content"]["text"]
+            if not "unknown" in impact:
+                print(" <a href=\""+metric["other"]["type"]+"\">["+impact+" severity]</a>")
+            
+    # Date
+    datepublic =cna["datePublic"]
+    print(" "+datepublic)
+
+    # Description
+    for desc in cna["descriptions"]:
+        print(desc["value"])
+
+    # Credits
+    if ("credits" in cna):
+        for credit in cna["credits"]:
+            print("Reported by "+credit["value"])
+
+    affects = []
+    product = cna["affected"][0]
+    productname = product['product']
+    for ver in product["versions"]:
+        if "lessThan" in ver:
+            fixedin = ver["lessThan"]
+            earliest = ver["version"]
+            git = ""
+            for reference in cna["references"]:
+                if reference["name"].startswith(fixedin+" git"):
+                    git = reference["url"]
+                    text = "Fixed in "+productname+" "+fixedin
+                    if (git != ""):
+                        text += " <a href=\""+git+"\">(git commit)</a>"
+                    text += " (Affected since "+earliest+")"
+                    print (text)
+
+    # Got everything ready to print out now
+    
+# Everything is sorted and pretty, this should be some python template thing
+
+print ("<h1>"+productname+" "+filterversion+" vulnerabilities</h1>")
+print ("<p>This page lists all security vulnerabilities fixed in released versions of "+productname+" "+filterversion+". Each vulnerability is given a security <a href=\"/security/impact_levels.html\">impact rating</a> by the Apache security team - please note that this rating may well vary from platform to platform.  We also list the versions the flaw is known to affect, and where a flaw has not been verified list the version with a question mark.</p>")
+print ("<p>Please note that if a vulnerability is shown below as being fixed in a \"-dev\" release then this means that a fix has been applied to the development source tree and will be part of an upcoming full release.</p>")
+print ("<p>Please send comments or corrections for these vulnerabilities to the <a href=\"/security_report.html\">Security Team</a>.</p> <br/>")
+
+if (options.extratext):
+    print ("<p>"+options.extratext+"</p><br/>")
+
+for sectioncves in sections:
+    print ("\n<h1 id=\""+sectioncves["fixed"]+"\">Fixed in "+sectioncves["product"]+" "+sectioncves["fixed"]+"</h1><dl>\n")
+    for e in sectioncves["cves"]:
+        html = "<dt><h3 id=\""+e['cveid']+"\">"+e['impact']+": <name name=\""+e['cveid']+"\">"+saxutils.escape(e['title'])+"</name>\n";
+        html += "(<a href=\"https://cve.mitre.org/cgi-bin/cvename.cgi?name="+e['cveid']+"\">"+e['cveid']+"</a>)</h3></dt>\n";
+        desc = saxutils.escape(e['desc'])
+        desc = re.sub(r'\n','</p><p>', desc)
+        html += "<dd><p>"+desc+"</p>\n"
+        if (e['credit'] != ""): html += "<p>Acknowledgements: "+saxutils.escape(e['credit'])+"</p>\n"
+        html += "<table class=\"cve\">"
+        e['timetable'].append(["Affects",e['affects']]);
+        for ti in e['timetable']:
+            html+= "<tr><td class=\"cve-header\">"+ti[0]+"</td><td class=\"cve-value\">"+ti[1]+"</td></tr>\n"
+        html+= "</table></dd>"
+        print (html.encode("utf-8"))
+    print ("</dl></br/>")
+
+

--- a/bin/cvejsontohtml.py
+++ b/bin/cvejsontohtml.py
@@ -48,11 +48,15 @@ for x in os.listdir(options.directory or "./"):
 # Filter on version 
 # We want to sort on reverse date then cve name
 statements = ""
+disputedcve = {}
 for cve in cves:
     if "statements" in cve:
         for statement in cve["statements"]:
             if (statement["base"] in (options.base or "none")):
                 statements +="<p>"+statement["text"].strip()+"</p>"
+    if "disputed" in cve:
+        for dispute in cve["disputed"]:
+            disputedcve[dispute["cve"]]=dispute
     if "containers" in cve:
         cna = cve["containers"]["cna"]
         cveid = cve["cveMetadata"]["cveId"]
@@ -177,8 +181,14 @@ if allissues != "":
 else:
     preface += "No vulnerabilities fixed"
 
-# TODO NONISSUES
+nonissues = ""
+for nonissue in disputedcve:
+    if (not options.base or disputedcve[nonissue]["base"] in (options.base or "none")):
+        nonissues += "<li><a href=\"https://cve.org/CVERecord?id=%s\" name=\"%s\">%s</a>: " %(nonissue,nonissue,nonissue)        
+        nonissues += disputedcve[nonissue]["text"]
+        nonissues +="</li>"
+if (nonissues != ""):
+    preface += "<h3>Not Vulnerabilities</h3><ul>" + nonissues + "</ul>"    
 
 sys.stdout.reconfigure(encoding='utf-8')
 sys.stdout.write(preface)
-

--- a/bin/cvejsontohtml.py
+++ b/bin/cvejsontohtml.py
@@ -47,17 +47,23 @@ for x in os.listdir(options.directory or "./"):
 
 # Filter on version 
 # We want to sort on reverse date then cve name
+statements = ""
 for cve in cves:
-    cna = cve["containers"]["cna"]
-    cveid = cve["cveMetadata"]["cveId"]
-    for version in cna["affected"][0]["versions"]:
-       fixedin = version["version"]
-       fixedbase = getbasefor(fixedin)
-       if fixedbase and fixedbase not in allbase:
-           allbase.append(fixedbase)
-       if (fixedin.startswith(base)):
-           datepublic = cna["datePublic"]+"-"+cveid
-           entries[datepublic]=cve
+    if "statements" in cve:
+        for statement in cve["statements"]:
+            if (statement["base"] in (options.base or "none")):
+                statements +="<p>"+statement["text"].strip()+"</p>"
+    if "containers" in cve:
+        cna = cve["containers"]["cna"]
+        cveid = cve["cveMetadata"]["cveId"]
+        for version in cna["affected"][0]["versions"]:
+            fixedin = version["version"]
+            fixedbase = getbasefor(fixedin)
+            if fixedbase and fixedbase not in allbase:
+                allbase.append(fixedbase)
+            if (fixedin.startswith(base)):
+                datepublic = cna["datePublic"]+"-"+cveid
+                entries[datepublic]=cve
 
 allbase = sorted(allbase, reverse=True)
            
@@ -162,7 +168,7 @@ if options.base:
     preface += "<h2>Fixed in OpenSSL %s</h2>" %(options.base)
 else:
     preface += "</p>"
-
+preface += statements
 if len(allyears)>1: # If only vulns in this year no need for the year table of contents
     preface += "<p><a name=\"toc\">Jump to year: </a>" + ", ".join( "<a href=\"#y%s\">%s</a>" %(year,year) for year in allyears)
 preface += "</p>"

--- a/bin/vulnxml2json.py
+++ b/bin/vulnxml2json.py
@@ -86,7 +86,7 @@ for issue in dom.getElementsByTagName('issue'):
     cve['problemtype'] = { "problemtype_data": [ { "description" : [ { "lang":"eng", "value": problemtype} ] } ] }
     impact = issue.getElementsByTagName('impact') # openssl does it like this
     if impact:
-        cve['impact'] = [ { "lang":"eng", "value":impact[0].getAttribute('severity'), "url":cfg.config['security_policy_url']+impact[0].getAttribute('severity') } ]
+        cve['impact'] = [ { "lang":"eng", "value":impact[0].getAttribute('severity'), "url":cfg.config['security_policy_url']+impact[0].getAttribute('severity').lower() } ]
     impact = issue.getElementsByTagName('severity')  # httpd does it like this
     if impact:
         cve['impact'] = [ { "lang":"eng", "value":impact[0].childNodes[0].nodeValue, "url":cfg.config['security_policy_url']+impact[0].childNodes[0].nodeValue } ]

--- a/bin/vulnxml2json5.py
+++ b/bin/vulnxml2json5.py
@@ -11,6 +11,7 @@ import html
 import simplejson as json
 import codecs
 import re
+import datetime
 from optparse import OptionParser
 
 # for validation
@@ -69,6 +70,9 @@ for issue in dom.getElementsByTagName('issue'):
     cve['cveMetadata']= { "cveId": "CVE-"+cvename, "assignerOrgId": cfg.config['orgId'], "state":"PUBLISHED" }
     cve['containers'] = dict()
     cve['containers']['cna']={"providerMetadata": {"orgId":cfg.config['orgId'],"shortName":cfg.config['project']}}
+
+    cve['containers']['cna']['x_generator']={"importer":"vulnxml2json5.py "+str(datetime.datetime.now())}
+    
     datepublic = issue.getAttribute("public")
     if datepublic:
        cve['containers']['cna']['datePublic'] = datepublic[:4]+'-'+datepublic[4:6]+'-'+datepublic[6:8]+"T00:00:00Z"
@@ -87,7 +91,10 @@ for issue in dom.getElementsByTagName('issue'):
         cve['containers']['cna']['problemTypes'] = [{ "descriptions": [ { "lang":"en", "description": problemtype} ] }]
     impact = issue.getElementsByTagName('impact') # openssl does it like this
     if impact:
-        cve['containers']['cna']['metrics'] = [ {  "format":"other", "other":{ "content":{"text":impact[0].getAttribute('severity')}, "type":cfg.config['security_policy_url']+impact[0].getAttribute('severity')}}]                                                
+        cve['containers']['cna']['metrics'] = [ {  "format":"other", "other":{ "content":{"text":impact[0].getAttribute('severity')}, "type":cfg.config['security_policy_url']+impact[0].getAttribute('severity')}}]
+    else:
+        # Impact is required or vulnogram will default to cvss
+        cve['containers']['cna']['metrics'] = [ {  "format":"other", "other":{ "content":{"text":"unknown"}, "type":cfg.config['security_policy_url']}}]
     impact = issue.getElementsByTagName('severity')  # httpd does it like this
     if impact:
         cve['containers']['cna']['metrics'] = [ { "format":"Other", "scenarios": [ {"lang":"en", "value":impact[0].childNodes[0].nodeValue, "url":cfg.config['security_policy_url']+impact[0].childNodes[0].nodeValue } ]}]

--- a/bin/vulnxml2json5.py
+++ b/bin/vulnxml2json5.py
@@ -135,7 +135,6 @@ for issue in dom.getElementsByTagName('issue'):
     for affects in issue.getElementsByTagName('fixed'): # OpenSSL and httpd since April 2018 does it this way
        text = f'Fixed in {cfg.config["product_name"]} {affects.getAttribute("version")} (Affected {cfg.merge_affects(issue,affects.getAttribute("base"))})'
        # Let's condense into a list form since the format of this field is 'free text' at the moment, not machine readable (as per mail with George Theall)
-       print (cvename)
        earliestver = cfg.earliest_affects(issue,affects.getAttribute("base"))
        if (not earliestver):
           earliestver = affects.getAttribute("base")
@@ -150,7 +149,8 @@ for issue in dom.getElementsByTagName('issue'):
        else: # like CVE-2016-2183
            vv.append({"version":earliestver,"status":"unaffected"})          
        # Mitre want the fixed/affected versions in the text too
-       desc += " "+text+"."
+       # let's not do this for json 5
+       # desc += " "+text+"."
 
 #    if issue.getAttribute('fixed'): # httpd used to do it this way
 #        base = ".".join(issue.getAttribute("fixed").split('.')[:-1])+"."

--- a/bin/vulnxml2json5.py
+++ b/bin/vulnxml2json5.py
@@ -1,0 +1,170 @@
+#! /usr/bin/python3
+#
+# Convert our XML file to a JSON file as accepted by Mitre for CNA purposes
+# as per https://github.com/CVEProject/automation-working-group/blob/master/cve_json_schema/DRAFT-JSON-file-format-v4.md
+#
+# ASF httpd and OpenSSL use quite similar files, so this script is designed to work with either
+#
+
+from xml.dom import minidom
+import html
+import simplejson as json
+import codecs
+import re
+from optparse import OptionParser
+
+# for validation
+import json
+import jsonschema
+from jsonschema import validate
+from jsonschema import Draft4Validator
+import urllib
+
+# Specific project stuff is here
+import vulnxml2jsonproject as cfg
+
+# Location of CVE JSON schema (default, can use local file etc)
+default_cve_schema = "https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/v5.0/docs/CVE_JSON_5.0_bundled.json"
+
+parser = OptionParser()
+parser.add_option("-s", "--schema", help="location of schema to check (default "+default_cve_schema+")", default=default_cve_schema,dest="schema")
+parser.add_option("-i", "--input", help="input vulnerability file vulnerabilities.xml", dest="input")
+parser.add_option("-c", "--cve", help="comma separated list of cve names to generate a json file for (or all)", dest="cves")
+parser.add_option("-o", "--outputdir", help="output directory for json file (default ./)", default=".", dest="outputdir")
+(options, args) = parser.parse_args()
+
+if not options.input:
+   print("needs input file")
+   parser.print_help()
+   exit();
+
+if options.schema:
+   try:
+      response = urllib.request.urlopen(options.schema)
+   except:
+      print(f'Problem opening schema: try downloading it manually then specify it using --schema option: {options.schema}')
+      exit()
+   schema_doc = json.loads(response.read())
+
+cvej = list()
+    
+with codecs.open(options.input,"r","utf-8") as vulnfile:
+    vulns = vulnfile.read()
+dom = minidom.parseString(vulns.encode("utf-8"))
+
+for issue in dom.getElementsByTagName('issue'):
+    if not issue.getElementsByTagName('cve'):
+        continue
+    # ASF httpd has CVE- prefix, but OpenSSL does not, make either work
+    cvename = issue.getElementsByTagName('cve')[0].getAttribute('name').replace('CVE-','')
+    if (cvename == ""):
+       continue
+    if (options.cves): # If we only want a certain list of CVEs, skip the rest
+       if (not cvename in options.cves):
+          continue
+
+    cve = dict()
+    cve['dataType']="CVE_RECORD"
+    cve['dataVersion']="5.0"
+    cve['cveMetadata']= { "cveId": "CVE-"+cvename, "assignerOrgId": cfg.config['orgId'], "state":"PUBLISHED" }
+    cve['containers'] = dict()
+    cve['containers']['cna']={"providerMetadata": {"orgId":cfg.config['orgId'],"shortName":cfg.config['project']}}
+    datepublic = issue.getAttribute("public")
+    if datepublic:
+       cve['containers']['cna']['datePublic'] = datepublic[:4]+'-'+datepublic[4:6]+'-'+datepublic[6:8]
+    if issue.getElementsByTagName('title'):
+       cve['containers']['cna']['title'] = issue.getElementsByTagName('title')[0].childNodes[0].nodeValue.strip()
+    desc = ""
+    for d in issue.getElementsByTagName('description')[0].childNodes:
+#        if d.nodeType == d.ELEMENT_NODE:
+            if desc:
+                desc += " "
+            desc += re.sub('<[^<]+?>', '', d.toxml().strip())
+    desc = html.unescape(desc)
+    problemtype = "(undefined)"
+    if issue.getElementsByTagName('problemtype'):
+        problemtype = issue.getElementsByTagName('problemtype')[0].childNodes[0].nodeValue.strip()
+    cve['containers']['cna']['problemTypes'] = [{ "descriptions": [ { "lang":"en", "description": problemtype} ] }]
+    impact = issue.getElementsByTagName('impact') # openssl does it like this
+    if impact:
+        cve['containers']['cna']['metrics'] = [ {  "format":"other", "other":{ "content":{"text":impact[0].getAttribute('severity')}, "type":cfg.config['security_policy_url']+impact[0].getAttribute('severity')}}]                                                
+    impact = issue.getElementsByTagName('severity')  # httpd does it like this
+    if impact:
+        cve['containers']['cna']['metrics'] = [ { "format":"Other", "scenarios": [ {"lang":"en", "value":impact[0].childNodes[0].nodeValue, "url":cfg.config['security_policy_url']+impact[0].childNodes[0].nodeValue } ]}]
+
+    # Create the list of credits
+    
+    credit = list()
+    for reported in issue.getElementsByTagName('reported'):  # openssl style credits
+        credit.append( { "lang":"en", "value":re.sub('[\n ]+',' ', reported.getAttribute("source"))} )
+    for reported in issue.getElementsByTagName('acknowledgements'): # ASF httpd style credits
+        credit.append(  { "lang":"en", "value":re.sub('[\n ]+',' ', reported.childNodes[0].nodeValue.strip())} )
+    if credit:
+        cve['containers']['cna']['credits']=credit
+
+    # Create the list of references
+    
+    refs = list()
+    for adv in issue.getElementsByTagName('advisory'):
+       url = adv.getAttribute("url")
+       if (not url.startswith("htt")):
+          url = cfg.config['default_reference_prefix']+url
+       refs.append({"url":url,"name":"OpenSSL Advisory","tags":["vendor-advisory"]})
+    for fixed in issue.getElementsByTagName('fixed'):
+       for git in fixed.getElementsByTagName('git'): # openssl style references to git
+          url = cfg.config['git_prefix']+git.getAttribute("hash")
+          refs.append({"url":url,"name":fixed.getAttribute('version')+" git commit","tags":["patch"]})
+    if cfg.config['project'] == 'httpd': # ASF httpd has no references so fake them
+       for fixed in issue.getElementsByTagName('fixed'):
+          base = "".join(fixed.getAttribute("version").split('.')[:-1])
+          refurl = cfg.config['default_reference']+base+".html#CVE-"+cvename
+          refs.append({"url":refurl,"name":refurl,"refsource":"CONFIRM"})
+    if refs:
+        cve['containers']['cna']['references'] = refs
+
+    # Create the "affected products" list
+        
+    vv = list()
+    for affects in issue.getElementsByTagName('fixed'): # OpenSSL and httpd since April 2018 does it this way
+       text = f'Fixed in {cfg.config["product_name"]} {affects.getAttribute("version")} (Affected {cfg.merge_affects(issue,affects.getAttribute("base"))})'
+       # Let's condense into a list form since the format of this field is 'free text' at the moment, not machine readable (as per mail with George Theall)
+       vv.append({"version":text,"status":"affected"})
+       # Mitre want the fixed/affected versions in the text too
+       desc += " "+text+"."
+
+#    if issue.getAttribute('fixed'): # httpd used to do it this way
+#        base = ".".join(issue.getAttribute("fixed").split('.')[:-1])+"."
+#        text = f'Fixed in {cfg.config["product_name"]} {cfg.merge_affects(issue,base)}'
+#        vv.append({"version_value":text})
+#        # Mitre want the fixed/affected versions in the text too
+#        desc += " "+text+"."            
+
+    cve['containers']['cna']['affected'] = [{ "vendor" : cfg.config['vendor_name'], "product": cfg.config['product_name'], "versions" : vv, "defaultStatus": "unaffected"}]
+            
+    # Mitre want newlines and excess spaces stripped
+    desc = re.sub('[\n ]+',' ', desc)        
+    cve['containers']['cna']['descriptions'] = [{ "lang":"en", "value": desc} ]
+
+    cvej.append(cve)
+        
+for issue in cvej:
+    fn = issue['cveMetadata']['cveId'] + ".json"
+    if not issue:
+       continue
+
+    f = codecs.open(options.outputdir+"/"+fn, 'w', 'utf-8')
+    f.write(json.dumps(issue, sort_keys=True, indent=4, separators=(',',': ')))
+    print(f'wrote {options.outputdir+"/"+fn}')
+    f.close()
+
+    try:
+       validate(issue, schema_doc)
+       print(f'{fn} passed validation')
+    except jsonschema.exceptions.ValidationError as incorrect:
+       v = Draft4Validator(schema_doc)
+       errors = sorted(v.iter_errors(issue), key=lambda e: e.path)
+       for error in errors:
+          print(f'{fn} did not pass validation: {str(error.message)}')
+    except NameError:
+       print(f'{fn} skipping validation, no schema defined')
+       

--- a/bin/vulnxml2json5.py
+++ b/bin/vulnxml2json5.py
@@ -91,7 +91,7 @@ for issue in dom.getElementsByTagName('issue'):
         cve['containers']['cna']['problemTypes'] = [{ "descriptions": [ { "lang":"en", "description": problemtype} ] }]
     impact = issue.getElementsByTagName('impact') # openssl does it like this
     if impact:
-        cve['containers']['cna']['metrics'] = [ {  "format":"other", "other":{ "content":{"text":impact[0].getAttribute('severity')}, "type":cfg.config['security_policy_url']+impact[0].getAttribute('severity')}}]
+        cve['containers']['cna']['metrics'] = [ {  "format":"other", "other":{ "content":{"text":impact[0].getAttribute('severity')}, "type":cfg.config['security_policy_url']+impact[0].getAttribute('severity').lower()}}]
     else:
         # Impact is required or vulnogram will default to cvss
         cve['containers']['cna']['metrics'] = [ {  "format":"other", "other":{ "content":{"text":"unknown"}, "type":cfg.config['security_policy_url']}}]

--- a/bin/vulnxml2json5.py
+++ b/bin/vulnxml2json5.py
@@ -84,6 +84,8 @@ for issue in dom.getElementsByTagName('issue'):
             if desc:
                 desc += " "
             desc += re.sub('<[^<]+?>', '', d.toxml().strip())
+            if not desc.endswith(".") and not desc.endswith(". "):
+               desc += ". "
     desc = html.unescape(desc)
 #    problemtype = "(undefined)"
     if issue.getElementsByTagName('problemtype'):
@@ -103,9 +105,9 @@ for issue in dom.getElementsByTagName('issue'):
     
     credit = list()
     for reported in issue.getElementsByTagName('reported'):  # openssl style credits
-        credit.append( { "lang":"en", "value":re.sub('[\n ]+',' ', reported.getAttribute("source"))} )
+        credit.append( { "lang":"en", "type": "finder", "value":re.sub('[\n ]+',' ', reported.getAttribute("source"))} )
     for reported in issue.getElementsByTagName('acknowledgements'): # ASF httpd style credits
-        credit.append(  { "lang":"en", "value":re.sub('[\n ]+',' ', reported.childNodes[0].nodeValue.strip())} )
+        credit.append(  { "lang":"en", "type":"finder",  "value":re.sub('[\n ]+',' ', reported.childNodes[0].nodeValue.strip())} )
     if credit:
         cve['containers']['cna']['credits']=credit
 

--- a/bin/vulnxml2jsonproject.py
+++ b/bin/vulnxml2jsonproject.py
@@ -13,16 +13,27 @@ config['security_policy_url'] = "https://www.openssl.org/policies/secpolicy.html
 config['git_prefix'] = "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h="
 config['default_reference_prefix'] = "https://www.openssl.org"
 
-def merge_affects(issue,base):
-    # let's merge the affects into a nice list which is better for Mitre text but we have to take into account our stange lettering scheme
-    prev = ""
-    anext = ""
-    alist = list()
+def get_vlist(issue,base):
     vlist = list()
     for affects in issue.getElementsByTagName('affects'): # so we can sort them
        version = affects.getAttribute("version")
        if (not base or base in version):
            vlist.append(version)
+    return vlist
+    
+def earliest_affects(issue,base):
+    vlist = get_vlist(issue,base)
+    if (not vlist):
+        return None
+    ver = sorted(vlist)[0]
+    return ver
+
+def merge_affects(issue,base):
+    # let's merge the affects into a nice list which is better for Mitre text but we have to take into account our stange lettering scheme
+    prev = ""
+    anext = ""
+    alist = list()
+    vlist = get_vlist(issue,base)
     for ver in sorted(vlist):
        # print(f'version {ver} (last was {prev}, next was {anext})')
        if (ver != anext):

--- a/bin/vulnxml2jsonproject.py
+++ b/bin/vulnxml2jsonproject.py
@@ -5,6 +5,7 @@ config = dict()
 config['project'] = "openssl"
 config['vendor_name'] = "OpenSSL"
 config['product_name'] = "OpenSSL"
+config['orgId'] = "b3476cb9-2e3d-41a6-98d0-0f47421a65b6"
 config['cve_meta_assigner'] = "openssl-security@openssl.org"
 # Versions of OpenSSL we never released, to allow us to display ranges
 config['neverreleased'] = "1.0.0h,"


### PR DESCRIPTION
Add cvejsontohtml.py which is used to generate the vulnerability pages from individual json files

Add vulnxml2json5.py the script we used to do the one-off creation of the json files from our vulnerabilities.xml. In theory it could be in some other tools place, but it might be useful in the future and it's okay to be public (as I use it for Apache conversions too)

Makefile updates to switch to using the JSON files as the main source of truth for vulnerability data.