### PR TITLE
Fix policy redirects

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,6 +14,8 @@ Redirect permanent  /.well-known/acme-challenge/MX5CvUJNvymcKf22SNORcfjGk4oGQyIW
 Redirect permanent /snapshot /source/snapshot
 Redirect permanent /policies/codingstyle.html /policies/technical/coding-style.html
 Redirect permanent /policies/secpolicy.html /policies/general/security-policy.html
+Redirect permanent /policies/travel.html /policies/general/travel-policy.html
+Redirect permanent /policies/platformpolicy.html /policies/general/platform-policy.html
 
 <Files *.md5>
 ForceType application/binary


### PR DESCRIPTION
We have recently removed two policies in favor of new ones in the general/
subdirectory.  For the benefit of anyone having links to the old policy
documents, we habitually add redirects so they get to the new version.
We forgot that for the platform and travel policies...
