### PR TITLE
Fix FIPS Menu Link

### DIFF
--- a/docs/dirdata.yaml
+++ b/docs/dirdata.yaml
@@ -8,5 +8,5 @@ sidebar:
 
     -   [FAQ](faq.html)
     -   [Manpages](manpages.html)
-    -   [Legacy FIPS-140 Validation](fips.html)
+    -   [FIPS-140 Validation](fips.html)
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,5 +21,5 @@ features and commands. It is updated often, and is available at
 <https://www.feistyduck.com/books/openssl-cookbook/>. It is highly
 recommended.
 
-Historic information about our legacy OpenSSL FIPS Object Module (FOM)
-2.0 [FIPS 140-2 validation](fips.html) is also available.
+Information related to the OpenSSL FIPS Validation
+[FIPS 140-2 validation](fips.html) is also available.


### PR DESCRIPTION
It is no longer a legacy FIPS validation.