### PR TITLE
Various updates to wording on the website following the 3.1 release

### DIFF
--- a/policies/releasestrat.md
+++ b/policies/releasestrat.md
@@ -3,7 +3,7 @@ breadcrumb: Release Strategy
 ---
 # Release Strategy
 
-#### First issued 23rd December 2014 Last modified 7th January 2020
+#### First issued 23rd December 2014 Last modified 14th March 2023
 
 As of release 3.0.0, the OpenSSL versioning scheme is changing to a more
 contemporary format: MAJOR.MINOR.PATCH
@@ -42,8 +42,11 @@ The current 1.1.1 versioning scheme remains unchanged:
 With regards to current and future releases the OpenSSL project has
 adopted the following policy:
 
+-   Version 3.1 will be supported until 2025-03-14
 -   Version 3.0 will be supported until 2026-09-07 (LTS).
--   Version 1.1.1 will be supported until 2023-09-11 (LTS).
+-   Version 1.1.1 will be supported until 2023-09-11 (LTS). Extended support for
+    1.1.1 to gain access to security fixes beyond that date for that version is
+    [available](/support/contracts.html).
 -   Version 1.0.2 is no longer supported. Extended support for 1.0.2 to
     gain access to security fixes for that version is
     [available](/support/contracts.html).

--- a/source/index.md
+++ b/source/index.md
@@ -14,14 +14,14 @@ of the numbering, see our [release strategy](/policies/releasestrat.html).)
 All releases can be found at [/source/old](old). A list of mirror sites can be
 found [here](mirror.html).
 
-*Note:* The latest stable version is the 3.0 series supported until 7th
-September 2026. This is also a Long Term Support (LTS) version. The
-previous LTS version (the 1.1.1 series) is also available and is
-supported until 11th September 2023. All older versions (including
-1.1.0, 1.0.2, 1.0.0 and 0.9.8) are now out of support and should not be
-used. Users of these older versions are encouraged to upgrade to 3.0 as
-soon as possible. Extended support for 1.0.2 to gain access to security
-fixes for that version is [available](/support/contracts.html).
+*Note:* The latest stable version is the 3.1 series supported until 14th March
+2025. Also available is the 3.0 series which is a Long Term Support (LTS)
+version and is supported until 7th September 2026. The previous LTS version (the
+1.1.1 series) is also available and is supported until 11th September 2023. All
+older versions (including 1.1.0, 1.0.2, 1.0.0 and 0.9.8) are now out of support
+and should not be used. Users of these older versions are encouraged to upgrade
+to 3.1 or 3.0 as soon as possible. Extended support for 1.0.2 to gain access to
+security fixes for that version is [available](/support/contracts.html).
 
 
 The following OpenSSL version(s) are FIPS validated.
@@ -32,7 +32,8 @@ and [Security Policy](https://csrc.nist.gov/CSRC/media/projects/cryptographic-mo
 Please follow the Security Policy instructions to download, build and
 install a validated OpenSSL FIPS provider.
 Other OpenSSL Releases MAY use the validated FIPS provider, but
-MUST NOT build and use their own FIPS provider.
+MUST NOT build and use their own FIPS provider. For example you can build
+OpenSSL 3.1 and use the OpenSSL 3.0.0 FIPS provider with it.
 
 Information about how to configure and use the FIPS provider in your
 applications is available on the FIPS module man page.
@@ -40,12 +41,12 @@ You must also read the module security policy and follow the specific
 build and installation instructions included in it.
 
 
-For an overview of some of the key concepts in OpenSSL 3.0 see the
+For an overview of some of the key concepts in OpenSSL 3.1 and 3.0 see the
 libcrypto [manual
-page](https://www.openssl.org/docs/man3.0/man7/crypto.html). Information
-and notes about migrating existing applications to OpenSSL 3.0 are
-available in the [OpenSSL 3.0 Migration
-Guide](https://www.openssl.org/docs/man3.0/man7/migration_guide.html)
+page](https://www.openssl.org/docs/man3.1/man7/crypto.html). Information
+and notes about migrating existing applications to OpenSSL 3.1 (and 3.0) are
+available in the [OpenSSL 3.1 Migration
+Guide](https://www.openssl.org/docs/man3.1/man7/migration_guide.html)
 
 <p>
 <table>

--- a/support/contracts.md
+++ b/support/contracts.md
@@ -31,7 +31,7 @@ US\$50,000 annually
 -   A support contract designed to meet the needs of Enterprise customers
 -   Provides extended support for LTS releases (including 1.0.2) beyond
     the public EOL date for as long as it remains commercially viable to
-    do so.
+    do so. This will also include 1.1.1 when that is beyond its public EOL date.
 -   Extended support includes provision of security fixes
 
 The premium support plan is intended for the large enterprise using


### PR DESCRIPTION
Updates to the download page to reflect that 3.1 is now the latest release. We also take the opportunity to update some things related to the forthcoming 1.1.1 EOL.