### PR TITLE
README: list all the dependencies to build this repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ a number of programs to be installed:
 
 -   [Template Toolkit].  The Debian package is `libtemplate-perl`
 -   [Pandoc].  The Debian package is `pandoc`
--   git
+-   `python3`, `wget` and `OpenSSL::Query` perl module.
 
 It also requires a checkout of a number of repositories and branches.  Some
 of the repositories may need specific access.  The `Makefile` requires that
@@ -81,6 +81,9 @@ layout:
 -   `openssl`
     (checkout of <https://github.com/openssl/openssl.git>,
     `master` branch)
+-   `openssl-3.1`
+    (checkout of <https://github.com/openssl/openssl.git>,
+    `openssl-3.1` branch)
 -   `openssl-3.0`
     (checkout of <https://github.com/openssl/openssl.git>,
     `openssl-3.0` branch)
@@ -89,7 +92,7 @@ layout:
     `OpenSSL_1_1_1-stable` branch)
 
 The checkouts directory can be given to `make` with the `CHECKOUTS`
-variable:
+variable. It is important to use an absolute path:
 
 ``` console
 $ make CHECKOUTS=/PATH/TO/checkouts


### PR DESCRIPTION
This is everything that you will need additionally install to a bare Debian/Ubuntu distro in order to build this repo.
It would be nice to have it listed in full here. It will save time someday to someone.

_For a later part, about absolute path... build does fail when you feed it relative path.
It is either in `./bin/mk-manpages3:16` or its caller._