### PR TITLE
Update FIPS and CVE page

### DIFF
--- a/news/fips-cve.md
+++ b/news/fips-cve.md
@@ -9,14 +9,13 @@ to the validated FIPS providers, a few of them are applicable.  This table
 lists all of the CVEs issued since the FIPS providers' releases and their
 relevance to it:
 
-
-CVE ID | Fixed | FIPS? | Notes
------ | :-: | :-: | :---------------
-[CVE-2023-2650] | 3.0.9 | no |
-[CVE-2023-1255] | 3.0.9 | **yes** | Possible denial of service on Arm 64 (aarch64) using AES XTS mode
-[CVE-2023-0466] | 3.0.9 | no |
-[CVE-2023-0465] | 3.0.9 | no |
-[CVE-2023-0464] | 3.0.9 | no |
+**CVE ID** | **Fixed** | **FIPS?** | **Notes**
+----- | --: | :-: | :---------------
+[CVE-2023-2650] | 3.0.9<br>3.1.1 | no |
+[CVE-2023-1255] | 3.0.9<br>3.1.1 | **yes** | Possible denial of service on Arm 64 (aarch64) using AES XTS mode
+[CVE-2023-0466] | 3.0.9<br>3.1.1 | no |
+[CVE-2023-0465] | 3.0.9<br>3.1.1 | no |
+[CVE-2023-0464] | 3.0.9<br>3.1.1 | no |
 | | | | **Release of 3.0.8 FIPS provider**
 [CVE-2023-0401] | 3.0.8 | no |
 [CVE-2023-0286] | 3.0.8 | no |

--- a/news/fips-cve.md
+++ b/news/fips-cve.md
@@ -11,6 +11,8 @@ relevance to it:
 
 **CVE ID** | **Fixed** | **FIPS?** | **Notes**
 ----- | --: | :-: | :---------------
+[CVE-2023-3446] | 3.0.10<br>3.1.2 | no |
+[CVE-2023-2975] | 3.0.10<br>3.1.2 | no |
 [CVE-2023-2650] | 3.0.9<br>3.1.1 | no |
 [CVE-2023-1255] | 3.0.9<br>3.1.1 | **yes** | Possible denial of service on Arm 64 (aarch64) using AES XTS mode
 [CVE-2023-0466] | 3.0.9<br>3.1.1 | no |
@@ -41,6 +43,8 @@ relevance to it:
 [CVE-2021-4044] | 3.0.1 | no |
 | | | | **Release of 3.0.0 FIPS provider**
 
+[CVE-2023-3446]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3446
+[CVE-2023-2975]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2975
 [CVE-2023-2650]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2650
 [CVE-2023-1255]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-1255
 [CVE-2023-0466]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0466

--- a/news/fips-cve.md
+++ b/news/fips-cve.md
@@ -11,6 +11,7 @@ relevance to it:
 
 **CVE ID** | **Fixed** | **FIPS?** | **Notes**
 ----- | --: | :-: | :---------------
+[CVE-2023-3817] | 3.0.10<br>3.1.2 | no |
 [CVE-2023-3446] | 3.0.10<br>3.1.2 | no |
 [CVE-2023-2975] | 3.0.10<br>3.1.2 | no |
 [CVE-2023-2650] | 3.0.9<br>3.1.1 | no |
@@ -43,6 +44,7 @@ relevance to it:
 [CVE-2021-4044] | 3.0.1 | no |
 | | | | **Release of 3.0.0 FIPS provider**
 
+[CVE-2023-3817]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3817
 [CVE-2023-3446]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3446
 [CVE-2023-2975]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2975
 [CVE-2023-2650]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2650


### PR DESCRIPTION
Adding CVE-2023-2975 and CVE-2023-3446 which are fixed in 3.0.10 and 3.1.2.

Also add 3.1.1 versions to the fixed column where useful.

Not to be published until the 3.0.10 and 3.1.2 releases are done.
