### PR TITLE
[about] Fix photo caption as rendered in the generated HTML

### DIFF
--- a/about.md
+++ b/about.md
@@ -10,7 +10,7 @@ security and privacy tools. Our dedicated team is at the helm of the OpenSSL
 project, ensuring secure digital interactions. Here, you'll meet the individuals
 who are collectively shaping a safer, privacy-respecting digital future.
 
-![team](/img/faces/openssl2023.png "Some of the OpenSSL team in 2023")
+![Some of the OpenSSL team in 2023](/img/faces/openssl2023.png "Some of the OpenSSL team in 2023")
 
 ## Aleš Mareček
 SysOps and DevOps Engineer, Security enthusiast, Quality driven, Bug hunter,

--- a/about.md
+++ b/about.md
@@ -10,7 +10,7 @@ security and privacy tools. Our dedicated team is at the helm of the OpenSSL
 project, ensuring secure digital interactions. Here, you'll meet the individuals
 who are collectively shaping a safer, privacy-respecting digital future.
 
-![Some of the OpenSSL team in 2023](/img/faces/openssl2023.png "Some of the OpenSSL team in 2023")
+![Some of the OpenSSL team in 2023, listed below in alphabetical order.](/img/faces/openssl2023.png "Some of the OpenSSL team in 2023")
 
 ## Aleš Mareček
 SysOps and DevOps Engineer, Security enthusiast, Quality driven, Bug hunter,


### PR DESCRIPTION
Someone pointed out to me the recent updates to the _About Us_ page, and I noticed that the rendered HTML offers a poor caption for the photograph:

![image](https://github.com/openssl/web/assets/338418/c438309e-8f84-4286-b102-618e49ab88e8)

This fixes it reusing the same text that ends up in the _alt_ description as the proper caption.