### PR TITLE
Ensure we correctly handle links to 1.1.1 commits

### DIFF
--- a/bin/cvejsontohtml.py
+++ b/bin/cvejsontohtml.py
@@ -213,8 +213,9 @@ for k, cve in sorted(entries.items(), reverse=True):
                     commitId = git.split(";")[-1].split("=")[-1]
                     git = f"https://github.com/openssl/openssl/commit/{commitId}"
                 if (
-                    fixedin.startswith("1.0.2") and fixedin[5] >= "w"
-                ):  # 1.0.2w and above hack
+                    (fixedin.startswith("1.0.2") and fixedin[5] >= "v")
+                    or (fixedin.startswith("1.1.1") and fixedin[5] >= "x")
+                ):  # 1.0.2v/1.1.1x and above hack
                     allissues += (
                         '<a href="/support/contracts.html?giturl=%s">(premium support)</a> '
                         % (git)


### PR DESCRIPTION
Commits for version 1.1.1x or above are premium support only

Also fixes the logic for 1.0.2 (the first premium support release was 1.0.2v)