### PR TITLE
Fix the table formatting in mailing lists page

### DIFF
--- a/community/mailinglists.md
+++ b/community/mailinglists.md
@@ -16,6 +16,8 @@ by all other members of the list.
 | [openssl-dev](https://mta.openssl.org/mailman/listinfo/openssl-dev)           | This is now a read-only list, and is archived.                                    |
 | [openssl-users](https://mta.openssl.org/mailman/listinfo/openssl-users)       | Any questions about building, using, etc., OpenSSL itself.                        |
 
+<p>&nbsp;</p>
+
 ## Archives
 
 Public archives can be found at the following locations:
@@ -27,6 +29,8 @@ Public archives can be found at the following locations:
 | openssl-project      | <https://marc.info/?l=openssl-project><br /><https://www.mail-archive.com/openssl-project@openssl.org/>                                                                 |
 | openssl-dev archives | <https://marc.info/?l=openssl-dev><br /><https://www.mail-archive.com/openssl-dev@openssl.org/><br /><https://groups.google.com/groups?group=mailing.openssl.dev>       |
 | openssl-commits      | <https://marc.info/?l=openssl-cvs><br /><https://groups.google.com/groups?group=mailing.openssl.cvs>                                                                    |
+
+<p>&nbsp;</p>
 
 Archives can also be found at our [mail server](https://mta.openssl.org/),
 under the page for each mailing list.

--- a/community/mailinglists.md
+++ b/community/mailinglists.md
@@ -8,9 +8,7 @@ be a member of the list to post to it. Anything you post to a list,
 including the E-mail address you posted from, will be sent to and seen
 by all other members of the list.
 
-<p>
-
-| List                                                                          | Purpose                                                                           |
+| **List**                                                                      | **Purpose**                                                                       |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | [openssl-announce](https://mta.openssl.org/mailman/listinfo/openssl-announce) | Official Project Announcements; low-volume read-only.                             |
 | [openssl-project](https://mta.openssl.org/mailman/listinfo/openssl-project)   | Discussion about the organization and structure of the project itself. Moderated. |
@@ -18,23 +16,17 @@ by all other members of the list.
 | [openssl-dev](https://mta.openssl.org/mailman/listinfo/openssl-dev)           | This is now a read-only list, and is archived.                                    |
 | [openssl-users](https://mta.openssl.org/mailman/listinfo/openssl-users)       | Any questions about building, using, etc., OpenSSL itself.                        |
 
-</p>
-
 ## Archives
 
 Public archives can be found at the following locations:
 
-<p>
-
-| List                 | Archives                                                                                                                                                                |
+| **List**             | **Archives**                                                                                                                                                            |
 |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | openssl-announce     | <https://marc.info/?l=openssl-announce><br /><https://www.mail-archive.com/openssl-announce@openssl.org/>                                                               |
 | openssl-users        | <https://marc.info/?l=openssl-users><br /><https://www.mail-archive.com/openssl-users@openssl.org/><br /><https://groups.google.com/groups?group=mailing.openssl.users> |
 | openssl-project      | <https://marc.info/?l=openssl-project><br /><https://www.mail-archive.com/openssl-project@openssl.org/>                                                                 |
 | openssl-dev archives | <https://marc.info/?l=openssl-dev><br /><https://www.mail-archive.com/openssl-dev@openssl.org/><br /><https://groups.google.com/groups?group=mailing.openssl.dev>       |
 | openssl-commits      | <https://marc.info/?l=openssl-cvs><br /><https://groups.google.com/groups?group=mailing.openssl.cvs>                                                                    |
-
-</p>
 
 Archives can also be found at our [mail server](https://mta.openssl.org/),
 under the page for each mailing list.

--- a/support/donations.md
+++ b/support/donations.md
@@ -22,14 +22,10 @@ organisation under Section 501(c)(3) of the U.S. Internal Revenue Code.
 We provide [Acknowledgements for sponsors](acks.html) depending on the level
 of funding:
 
-<p>
-
-| Level                         | Acknowledgement                                                   |
+| **Level**                     | **Acknowledgement**                                               |
 |-------------------------------|-------------------------------------------------------------------|
 | Exceptional<br />\$75,000+/yr | Logo placement on openssl.org<br />Acknowledgement on openssl.org |
 | Platinum<br />\$50,000+/yr    | Logo placement on openssl.org<br />Acknowledgement on openssl.org |
 | Gold<br />\$20,000+/yr        | Logo placement on openssl.org<br />Acknowledgement on openssl.org |
 | Silver<br />\$10,000+/yr      | Acknowledgement on openssl.org                                    |
 | Bronze<br />\$5,000+/yr       | Acknowledgement on openssl.org                                    |
-
-</p>


### PR DESCRIPTION
The table formating was broken since we do not allow Markdown formatting parsing inside HTML anymore.
