### PR TITLE
Remove VeriSign as a Silver Sponsor

### DIFF
--- a/support/acks.md
+++ b/support/acks.md
@@ -47,8 +47,6 @@ note sponsors may choose to remain anonymous.
 
 <div class="sponsorsection">
 
-[VeriSign, Inc.](https://www.verisign.com/)
-
 </div>
 
 ### Bronze:


### PR DESCRIPTION
VeriSign is not renewing their donation as a Silver Sponsor this year. Removed them from the sponsor page.