### PR TITLE
Remove html tags from markdown, causing broken page rendering

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,6 +15,7 @@ Redirect permanent /policies/codingstyle.html /policies/technical/coding-style.h
 Redirect permanent /policies/secpolicy.html /policies/general/security-policy.html
 Redirect permanent /policies/travel.html /policies/general/travel-policy.html
 Redirect permanent /policies/platformpolicy.html /policies/general/platform-policy.html
+Redirect permanent /community/thanks.html /support/acks.html
 
 <Files *.md5>
 ForceType application/binary

--- a/source/mirror.md
+++ b/source/mirror.md
@@ -6,8 +6,6 @@ breadcrumb: Mirrors
 You can download the latest distribution files from the following FTP
 areas:
 
-<p>
-
 | Locale | URL                                                |
 |--------|----------------------------------------------------|
 | CZ     | <ftp://ftp.fi.muni.cz/pub/openssl/>                |
@@ -17,7 +15,5 @@ areas:
 | HU     | <ftp://ftp.kfki.hu/pub/packages/security/openssl/> |
 | PL     | <ftp://guest.kuria.katowice.pl/pub/openssl/>       |
 | PL     | <rsync://ftp.tpnet.pl/pub/security/openssl/>       |
-
-</p>
 
 We are not interested in adding additional mirrors at the time.

--- a/support/acks.md
+++ b/support/acks.md
@@ -63,11 +63,4 @@ note sponsors may choose to remain anonymous.
 
 </div>
 
-------------------------------------------------------------------------
 
-## Other Donations
-
-We also would like to thank those who contribute via [GitHub
-Sponsors](https://github.com/sponsors/openssl), as well as the
-organizations who contribute [in-kind donations to the
-project](/community/thanks.html).


### PR DESCRIPTION
The "mirrors" web page on the openssl page seems to be broken:
https://www.openssl.org/source/mirror.html

It appears there are some leftover html tags in the markdown, and those break the rendering of the markdown table. Removing them fixes it.